### PR TITLE
Add initial RescueGroups Sync plugin scaffold

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -1,0 +1,5 @@
+# RescueGroups Sync
+
+This plugin synchronizes adoptable pets from the RescueGroups.org API and registers a custom post type for displaying them.
+
+**Work in progress.**

--- a/rescuegroups-sync/includes/class-admin.php
+++ b/rescuegroups-sync/includes/class-admin.php
@@ -1,0 +1,16 @@
+<?php
+namespace RescueSync;
+
+class Admin {
+    public function __construct() {
+        add_action( 'admin_menu', [ $this, 'add_settings_page' ] );
+    }
+
+    public function add_settings_page() {
+        add_options_page( 'Rescue Sync', 'Rescue Sync', 'manage_options', 'rescue-sync', [ $this, 'render_settings_page' ] );
+    }
+
+    public function render_settings_page() {
+        echo '<div class="wrap"><h1>Rescue Sync Settings</h1></div>';
+    }
+}

--- a/rescuegroups-sync/includes/class-api-client.php
+++ b/rescuegroups-sync/includes/class-api-client.php
@@ -1,0 +1,25 @@
+<?php
+namespace RescueSync;
+
+class API_Client {
+    protected $api_key;
+
+    public function __construct( $api_key ) {
+        $this->api_key = $api_key;
+    }
+
+    public function get_available_animals( $page = 1 ) {
+        $url = 'https://api.rescuegroups.org/v5/public/animals/search/available?limit=100&page=' . intval( $page );
+        $response = wp_remote_get( $url, [
+            'headers' => [ 'x-api-key' => $this->api_key ],
+        ] );
+
+        if ( is_wp_error( $response ) ) {
+            return [];
+        }
+
+        $body = wp_remote_retrieve_body( $response );
+        $data = json_decode( $body, true );
+        return $data ? $data : [];
+    }
+}

--- a/rescuegroups-sync/includes/class-cpt.php
+++ b/rescuegroups-sync/includes/class-cpt.php
@@ -1,0 +1,23 @@
+<?php
+namespace RescueSync;
+
+class CPT {
+    public function __construct() {
+        add_action( 'init', [ $this, 'register_cpt' ] );
+    }
+
+    public function register_cpt() {
+        $labels = [
+            'name' => 'Adoptable Pets',
+            'singular_name' => 'Adoptable Pet',
+        ];
+        $args = [
+            'labels' => $labels,
+            'public' => true,
+            'supports' => [ 'title', 'editor', 'thumbnail' ],
+            'has_archive' => true,
+            'rewrite' => [ 'slug' => 'adopt' ],
+        ];
+        register_post_type( 'adoptable_pet', $args );
+    }
+}

--- a/rescuegroups-sync/includes/class-sync.php
+++ b/rescuegroups-sync/includes/class-sync.php
@@ -1,0 +1,12 @@
+<?php
+namespace RescueSync;
+
+class Sync {
+    public function __construct() {
+        add_action( 'rescue_sync_cron', [ $this, 'run' ] );
+    }
+
+    public function run() {
+        // Placeholder for sync logic.
+    }
+}

--- a/rescuegroups-sync/includes/class-utils.php
+++ b/rescuegroups-sync/includes/class-utils.php
@@ -1,0 +1,8 @@
+<?php
+namespace RescueSync;
+
+class Utils {
+    public static function get_option( $key, $default = '' ) {
+        return get_option( 'rescue_sync_' . $key, $default );
+    }
+}

--- a/rescuegroups-sync/includes/class-widgets.php
+++ b/rescuegroups-sync/includes/class-widgets.php
@@ -1,0 +1,12 @@
+<?php
+namespace RescueSync;
+
+class Widgets {
+    public function __construct() {
+        add_action( 'widgets_init', [ $this, 'register_widgets' ] );
+    }
+
+    public function register_widgets() {
+        // Placeholder for widget registration.
+    }
+}

--- a/rescuegroups-sync/rescuegroups-sync.php
+++ b/rescuegroups-sync/rescuegroups-sync.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Plugin Name: RescueGroups Sync
+ * Description: Syncs adoptable animals from RescueGroups.org and displays them as custom posts.
+ * Version: 0.1.0
+ * Author: Your Name
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+define( 'RESCUE_SYNC_VERSION', '0.1.0' );
+
+define( 'RESCUE_SYNC_DIR', plugin_dir_path( __FILE__ ) );
+define( 'RESCUE_SYNC_URL', plugin_dir_url( __FILE__ ) );
+
+spl_autoload_register( function( $class ) {
+    if ( 0 !== strpos( $class, 'RescueSync\\' ) ) {
+        return;
+    }
+    $path = RESCUE_SYNC_DIR . 'includes/' . str_replace( '\\', '/', strtolower( str_replace( 'RescueSync\\', '', $class ) ) ) . '.php';
+    if ( file_exists( $path ) ) {
+        require $path;
+    }
+});
+
+// Initialize components.
+add_action( 'plugins_loaded', function() {
+    if ( class_exists( 'RescueSync\\CPT' ) ) {
+        new RescueSync\CPT();
+    }
+    if ( class_exists( 'RescueSync\\Admin' ) ) {
+        new RescueSync\Admin();
+    }
+    if ( class_exists( 'RescueSync\\Sync' ) ) {
+        new RescueSync\Sync();
+    }
+    if ( class_exists( 'RescueSync\\Widgets' ) ) {
+        new RescueSync\Widgets();
+    }
+} );

--- a/rescuegroups-sync/uninstall.php
+++ b/rescuegroups-sync/uninstall.php
@@ -1,0 +1,9 @@
+<?php
+// If uninstall not called from WordPress, exit.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit();
+}
+
+// Remove options.
+delete_option( 'rescue_sync_api_key' );
+// More cleanup to be added.


### PR DESCRIPTION
## Summary
- scaffold the plugin directory `rescuegroups-sync`
- add bootstrap file and autoloader
- set up class placeholders for CPT, API client, sync, admin, widgets, and utils
- add uninstall script and README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849e3e1996c8326b83586b9bf9b7150