### PR TITLE
Fix autoloader paths

### DIFF
--- a/rescuegroups-sync/rescuegroups-sync.php
+++ b/rescuegroups-sync/rescuegroups-sync.php
@@ -17,7 +17,14 @@ spl_autoload_register( function( $class ) {
     if ( 0 !== strpos( $class, 'RescueSync\\' ) ) {
         return;
     }
-    $path = RESCUE_SYNC_DIR . 'includes/' . str_replace( '\\', '/', strtolower( str_replace( 'RescueSync\\', '', $class ) ) ) . '.php';
+
+    $relative = str_replace( 'RescueSync\\', '', $class );
+    $relative = str_replace( '\\', '-', $relative );
+    $relative = str_replace( '_', '-', $relative );
+    $relative = preg_replace( '/([a-z])([A-Z])/', '$1-$2', $relative );
+    $relative = strtolower( $relative );
+
+    $path = RESCUE_SYNC_DIR . 'includes/class-' . $relative . '.php';
     if ( file_exists( $path ) ) {
         require $path;
     }


### PR DESCRIPTION
## Summary
- update autoloader to prepend `class-` and hyphenate file names

## Testing
- `php -l rescuegroups-sync/rescuegroups-sync.php`
- `php test_autoload.php`

------
https://chatgpt.com/codex/tasks/task_e_6849f253b5e48326a5f60aa77dd2ae35