### PR TITLE
Implement cron sync for RescueGroups plugin

### DIFF
--- a/rescuegroups-sync/includes/class-sync.php
+++ b/rescuegroups-sync/includes/class-sync.php
@@ -2,11 +2,86 @@
 namespace RescueSync;
 
 class Sync {
+
+    /**
+     * Constructor.
+     *
+     * Adds the cron hook for running the sync process.
+     */
     public function __construct() {
         add_action( 'rescue_sync_cron', [ $this, 'run' ] );
     }
 
+    /**
+     * Schedule the cron event when the plugin is activated.
+     */
+    public static function activate() {
+        if ( ! wp_next_scheduled( 'rescue_sync_cron' ) ) {
+            wp_schedule_event( time(), 'hourly', 'rescue_sync_cron' );
+        }
+    }
+
+    /**
+     * Clear the cron event when the plugin is deactivated.
+     */
+    public static function deactivate() {
+        $timestamp = wp_next_scheduled( 'rescue_sync_cron' );
+        if ( $timestamp ) {
+            wp_unschedule_event( $timestamp, 'rescue_sync_cron' );
+        }
+    }
+
+    /**
+     * Fetch animals from the API and create/update posts.
+     */
     public function run() {
-        // Placeholder for sync logic.
+        $api_key = Utils::get_option( 'api_key' );
+        if ( empty( $api_key ) ) {
+            return;
+        }
+
+        $client  = new API_Client( $api_key );
+        $results = $client->get_available_animals();
+
+        if ( empty( $results['data'] ) || ! is_array( $results['data'] ) ) {
+            return;
+        }
+
+        foreach ( $results['data'] as $animal ) {
+            $animal_id = isset( $animal['id'] ) ? intval( $animal['id'] ) : 0;
+            if ( ! $animal_id ) {
+                continue;
+            }
+
+            $name        = isset( $animal['attributes']['name'] ) ? $animal['attributes']['name'] : '';
+            $description = isset( $animal['attributes']['descriptionText'] ) ? $animal['attributes']['descriptionText'] : '';
+
+            $query = new \WP_Query([
+                'post_type'      => 'adoptable_pet',
+                'post_status'    => 'any',
+                'meta_key'       => 'rescuegroups_id',
+                'meta_value'     => $animal_id,
+                'fields'         => 'ids',
+                'posts_per_page' => 1,
+            ]);
+
+            $post_args = [
+                'post_title'   => sanitize_text_field( $name ),
+                'post_content' => wp_kses_post( $description ),
+                'post_status'  => 'publish',
+                'post_type'    => 'adoptable_pet',
+            ];
+
+            if ( $query->have_posts() ) {
+                $post_args['ID'] = $query->posts[0];
+            }
+
+            $post_id = wp_insert_post( $post_args );
+
+            if ( ! is_wp_error( $post_id ) ) {
+                update_post_meta( $post_id, 'rescuegroups_id', $animal_id );
+                update_post_meta( $post_id, 'rescuegroups_raw', wp_json_encode( $animal ) );
+            }
+        }
     }
 }

--- a/rescuegroups-sync/rescuegroups-sync.php
+++ b/rescuegroups-sync/rescuegroups-sync.php
@@ -23,6 +23,9 @@ spl_autoload_register( function( $class ) {
     }
 });
 
+register_activation_hook( __FILE__, [ 'RescueSync\\Sync', 'activate' ] );
+register_deactivation_hook( __FILE__, [ 'RescueSync\\Sync', 'deactivate' ] );
+
 // Initialize components.
 add_action( 'plugins_loaded', function() {
     if ( class_exists( 'RescueSync\\CPT' ) ) {


### PR DESCRIPTION
## Summary
- schedule hourly `rescue_sync_cron` events on activation
- clear the scheduled event on deactivation
- implement sync logic to fetch animals and create/update `adoptable_pet` posts

## Testing
- `php -l rescuegroups-sync/includes/class-sync.php`
- `php -l rescuegroups-sync/rescuegroups-sync.php`

------
https://chatgpt.com/codex/tasks/task_e_6849f25dd12c8326b9eb6672881a2a19