### PR TITLE
Add plugin headers and README sections

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -3,3 +3,22 @@
 This plugin synchronizes adoptable pets from the RescueGroups.org API and registers a custom post type for displaying them.
 
 **Work in progress.**
+
+## Installation
+
+1. Upload the `rescuegroups-sync` directory to your `/wp-content/plugins/` folder.
+2. Activate the plugin through the **Plugins** menu in WordPress.
+3. Ensure your server is running PHP 7.2 or greater.
+
+## Configuration
+
+1. Obtain an API key from [RescueGroups.org](https://rescuegroups.org/).
+2. In the WordPress admin, go to **Rescue Sync** under **Settings**.
+3. Enter your API key and save the settings.
+4. Use the provided widgets or shortcodes to display pets on your site.
+
+## Roadmap
+
+- Additional settings and customization options.
+- Gutenberg block support.
+- More extensive cleanup on uninstall.

--- a/rescuegroups-sync/rescuegroups-sync.php
+++ b/rescuegroups-sync/rescuegroups-sync.php
@@ -1,11 +1,17 @@
 <?php
 /**
  * Plugin Name: RescueGroups Sync
+ * Plugin URI: https://example.com/rescuegroups-sync
  * Description: Syncs adoptable animals from RescueGroups.org and displays them as custom posts.
  * Version: 0.1.0
+ * Requires at least: 5.6
+ * Requires PHP: 7.2
  * Author: Your Name
+ * Author URI: https://example.com
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain: rescuegroups-sync
+ * Domain Path: /languages
  */
 
 define( 'RESCUE_SYNC_VERSION', '0.1.0' );


### PR DESCRIPTION
## Summary
- add standard plugin headers to `rescuegroups-sync.php`
- expand `README.md` with installation, configuration and roadmap sections

## Testing
- `php -l rescuegroups-sync/rescuegroups-sync.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849f265901483269250954317ad0f3e