### PR TITLE
Add settings page API key input

### DIFF
--- a/rescuegroups-sync/includes/class-admin.php
+++ b/rescuegroups-sync/includes/class-admin.php
@@ -4,6 +4,14 @@ namespace RescueSync;
 class Admin {
     public function __construct() {
         add_action( 'admin_menu', [ $this, 'add_settings_page' ] );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+    }
+
+    public function register_settings() {
+        register_setting( 'rescue_sync', 'rescue_sync_api_key', [
+            'type' => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+        ] );
     }
 
     public function add_settings_page() {
@@ -11,6 +19,27 @@ class Admin {
     }
 
     public function render_settings_page() {
-        echo '<div class="wrap"><h1>Rescue Sync Settings</h1></div>';
+        ?>
+        <div class="wrap">
+            <h1><?php echo esc_html( 'Rescue Sync Settings' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields( 'rescue_sync' );
+                $api_key = Utils::get_option( 'api_key' );
+                ?>
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row">
+                            <label for="rescue_sync_api_key"><?php echo esc_html( 'API Key' ); ?></label>
+                        </th>
+                        <td>
+                            <input name="rescue_sync_api_key" id="rescue_sync_api_key" type="text" value="<?php echo esc_attr( $api_key ); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
     }
 }

--- a/rescuegroups-sync/includes/class-utils.php
+++ b/rescuegroups-sync/includes/class-utils.php
@@ -5,4 +5,8 @@ class Utils {
     public static function get_option( $key, $default = '' ) {
         return get_option( 'rescue_sync_' . $key, $default );
     }
+
+    public static function get_api_key() {
+        return self::get_option( 'api_key' );
+    }
 }


### PR DESCRIPTION
## Summary
- register `rescue_sync_api_key` setting
- add API key input form to the settings page
- add utility method to retrieve the API key

## Testing
- `php -l rescuegroups-sync/includes/class-admin.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849f6ceeca0832687d7cf91f82c2eac