### PR TITLE
Flush rewrite rules on activation

### DIFF
--- a/rescuegroups-sync/includes/class-sync.php
+++ b/rescuegroups-sync/includes/class-sync.php
@@ -16,6 +16,22 @@ class Sync {
      * Schedule the cron event when the plugin is activated.
      */
     public static function activate() {
+        // Ensure the custom post type is registered so rewrite rules exist.
+        $labels = [
+            'name'          => 'Adoptable Pets',
+            'singular_name' => 'Adoptable Pet',
+        ];
+        $args   = [
+            'labels'      => $labels,
+            'public'      => true,
+            'supports'    => [ 'title', 'editor', 'thumbnail' ],
+            'has_archive' => true,
+            'rewrite'     => [ 'slug' => 'adopt' ],
+        ];
+        register_post_type( 'adoptable_pet', $args );
+
+        flush_rewrite_rules();
+
         if ( ! wp_next_scheduled( 'rescue_sync_cron' ) ) {
             wp_schedule_event( time(), 'hourly', 'rescue_sync_cron' );
         }


### PR DESCRIPTION
## Summary
- register the custom post type and flush rewrite rules when activating the plugin

## Testing
- `php -l rescuegroups-sync/includes/class-sync.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849fea7a6bc8326a07fe1182feab238