### PR TITLE
Add sync scheduling options and manual trigger

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -15,7 +15,8 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
 1. Obtain an API key from [RescueGroups.org](https://rescuegroups.org/).
 2. In the WordPress admin, go to **Rescue Sync** under **Settings**.
 3. Enter your API key and save the settings.
-4. Use the provided widgets or shortcodes to display pets on your site.
+4. Choose how often the sync should run and optionally trigger a manual sync.
+5. Use the provided widgets or shortcodes to display pets on your site.
 
 ## Roadmap
 

--- a/rescuegroups-sync/includes/class-sync.php
+++ b/rescuegroups-sync/includes/class-sync.php
@@ -17,7 +17,8 @@ class Sync {
      */
     public static function activate() {
         if ( ! wp_next_scheduled( 'rescue_sync_cron' ) ) {
-            wp_schedule_event( time(), 'hourly', 'rescue_sync_cron' );
+            $frequency = Utils::get_option( 'frequency', 'hourly' );
+            wp_schedule_event( time(), $frequency, 'rescue_sync_cron' );
         }
     }
 
@@ -37,6 +38,8 @@ class Sync {
     public function run() {
         $api_key = Utils::get_option( 'api_key' );
         if ( empty( $api_key ) ) {
+            update_option( 'rescue_sync_last_sync', current_time( 'timestamp' ) );
+            update_option( 'rescue_sync_last_status', 'missing_api_key' );
             return;
         }
 
@@ -44,6 +47,8 @@ class Sync {
         $results = $client->get_available_animals();
 
         if ( empty( $results['data'] ) || ! is_array( $results['data'] ) ) {
+            update_option( 'rescue_sync_last_sync', current_time( 'timestamp' ) );
+            update_option( 'rescue_sync_last_status', 'no_data' );
             return;
         }
 
@@ -83,5 +88,8 @@ class Sync {
                 update_post_meta( $post_id, 'rescuegroups_raw', wp_json_encode( $animal ) );
             }
         }
+
+        update_option( 'rescue_sync_last_sync', current_time( 'timestamp' ) );
+        update_option( 'rescue_sync_last_status', 'success' );
     }
 }

--- a/rescuegroups-sync/uninstall.php
+++ b/rescuegroups-sync/uninstall.php
@@ -6,4 +6,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 // Remove options.
 delete_option( 'rescue_sync_api_key' );
+delete_option( 'rescue_sync_frequency' );
+delete_option( 'rescue_sync_last_sync' );
+delete_option( 'rescue_sync_last_status' );
 // More cleanup to be added.


### PR DESCRIPTION
## Summary
- allow configuration of sync frequency
- add manual sync button and handler
- persist last sync timestamp and status
- adjust cron activation to respect the chosen frequency
- document new options

## Testing
- `php -l rescuegroups-sync/includes/class-admin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a0090fb44832682eb0affcf11dbfa