### PR TITLE
Implement adoptable_pets shortcode

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -15,7 +15,26 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
 1. Obtain an API key from [RescueGroups.org](https://rescuegroups.org/).
 2. In the WordPress admin, go to **Rescue Sync** under **Settings**.
 3. Enter your API key and save the settings.
-4. Use the provided widgets or shortcodes to display pets on your site.
+4. Use the provided widgets or shortcode to display pets on your site.
+
+## Shortcode Usage
+
+Display a list of adoptable pets anywhere on your site using the `[adoptable_pets]` shortcode.
+
+```
+[adoptable_pets]
+```
+
+### Parameters
+
+- `number` - Number of pets to show. Default is `5`.
+- `featured_only` - Set to `1` to show only pets marked as featured.
+
+Example showing eight featured pets:
+
+```
+[adoptable_pets number="8" featured_only="1"]
+```
 
 ## Roadmap
 

--- a/rescuegroups-sync/includes/class-shortcodes.php
+++ b/rescuegroups-sync/includes/class-shortcodes.php
@@ -1,0 +1,57 @@
+<?php
+namespace RescueSync;
+
+class Shortcodes {
+    public function __construct() {
+        add_shortcode( 'adoptable_pets', [ $this, 'adoptable_pets' ] );
+    }
+
+    /**
+     * Shortcode handler for [adoptable_pets].
+     *
+     * @param array $atts Shortcode attributes.
+     * @return string HTML output.
+     */
+    public function adoptable_pets( $atts = [] ) {
+        $atts = shortcode_atts(
+            [
+                'number'       => 5,
+                'featured_only'=> false,
+            ],
+            $atts,
+            'adoptable_pets'
+        );
+
+        $query_args = [
+            'post_type'      => 'adoptable_pet',
+            'posts_per_page' => absint( $atts['number'] ),
+            'post_status'    => 'publish',
+        ];
+
+        if ( ! empty( $atts['featured_only'] ) ) {
+            $query_args['meta_query'] = [
+                [
+                    'key'   => 'featured',
+                    'value' => '1',
+                ],
+            ];
+        }
+
+        $query = new \WP_Query( $query_args );
+        ob_start();
+        echo '<ul class="adoptable-pets-shortcode">';
+        if ( $query->have_posts() ) {
+            while ( $query->have_posts() ) {
+                $query->the_post();
+                printf(
+                    '<li><a href="%s">%s</a></li>',
+                    esc_url( get_permalink() ),
+                    esc_html( get_the_title() )
+                );
+            }
+        }
+        echo '</ul>';
+        \wp_reset_postdata();
+        return ob_get_clean();
+    }
+}

--- a/rescuegroups-sync/rescuegroups-sync.php
+++ b/rescuegroups-sync/rescuegroups-sync.php
@@ -53,4 +53,7 @@ add_action( 'plugins_loaded', function() {
     if ( class_exists( 'RescueSync\\Widgets' ) ) {
         new RescueSync\Widgets();
     }
+    if ( class_exists( 'RescueSync\\Shortcodes' ) ) {
+        new RescueSync\Shortcodes();
+    }
 } );


### PR DESCRIPTION
## Summary
- add `Shortcodes` class with `[adoptable_pets]` handler
- register shortcodes on plugin init
- document shortcode usage

## Testing
- `php -l rescuegroups-sync/includes/class-shortcodes.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a0092f8f88326a4ae2df7e756b80e