### PR TITLE
Add ABSPATH guard and text domain loading

### DIFF
--- a/rescuegroups-sync/includes/class-admin.php
+++ b/rescuegroups-sync/includes/class-admin.php
@@ -17,13 +17,13 @@ class Admin {
     }
 
     public function add_settings_page() {
-        add_options_page( 'Rescue Sync', 'Rescue Sync', 'manage_options', 'rescue-sync', [ $this, 'render_settings_page' ] );
+        add_options_page( __( 'Rescue Sync', 'rescuegroups-sync' ), __( 'Rescue Sync', 'rescuegroups-sync' ), 'manage_options', 'rescue-sync', [ $this, 'render_settings_page' ] );
     }
 
     public function render_settings_page() {
         ?>
         <div class="wrap">
-            <h1><?php echo esc_html( 'Rescue Sync Settings' ); ?></h1>
+            <h1><?php echo esc_html__( 'Rescue Sync Settings', 'rescuegroups-sync' ); ?></h1>
             <form method="post" action="options.php">
                 <?php
                 settings_fields( 'rescue_sync' );
@@ -32,7 +32,7 @@ class Admin {
                 <table class="form-table" role="presentation">
                     <tr>
                         <th scope="row">
-                            <label for="rescue_sync_api_key"><?php echo esc_html( 'API Key' ); ?></label>
+                            <label for="rescue_sync_api_key"><?php echo esc_html__( 'API Key', 'rescuegroups-sync' ); ?></label>
                         </th>
                         <td>
                             <input name="rescue_sync_api_key" id="rescue_sync_api_key" type="text" value="<?php echo esc_attr( $api_key ); ?>" class="regular-text" />

--- a/rescuegroups-sync/includes/class-cpt.php
+++ b/rescuegroups-sync/includes/class-cpt.php
@@ -9,8 +9,8 @@ class CPT {
 
     public function register_cpt() {
         $labels = [
-            'name' => 'Adoptable Pets',
-            'singular_name' => 'Adoptable Pet',
+            'name'          => __( 'Adoptable Pets', 'rescuegroups-sync' ),
+            'singular_name' => __( 'Adoptable Pet', 'rescuegroups-sync' ),
         ];
         $args = [
             'labels' => $labels,

--- a/rescuegroups-sync/rescuegroups-sync.php
+++ b/rescuegroups-sync/rescuegroups-sync.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 /**
  * Plugin Name: RescueGroups Sync
  * Plugin URI: https://example.com/rescuegroups-sync
@@ -18,6 +21,11 @@ define( 'RESCUE_SYNC_VERSION', '0.1.0' );
 
 define( 'RESCUE_SYNC_DIR', plugin_dir_path( __FILE__ ) );
 define( 'RESCUE_SYNC_URL', plugin_dir_url( __FILE__ ) );
+
+function rescuegroups_sync_load_textdomain() {
+    load_plugin_textdomain( 'rescuegroups-sync', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'plugins_loaded', 'rescuegroups_sync_load_textdomain' );
 
 spl_autoload_register( function( $class ) {
     if ( 0 !== strpos( $class, 'RescueSync\\' ) ) {


### PR DESCRIPTION
## Summary
- add ABSPATH guard to plugin entry point
- load plugin text domain at `plugins_loaded`
- internationalize admin page labels and CPT labels with `'rescuegroups-sync'`

## Testing
- `php -l rescuegroups-sync/rescuegroups-sync.php` *(fails: command not found)*
- `php -l rescuegroups-sync/includes/class-admin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0762793883269c45dbb6361cbcbd