### PR TITLE
Internationalize admin labels

### DIFF
--- a/rescuegroups-sync/includes/class-admin.php
+++ b/rescuegroups-sync/includes/class-admin.php
@@ -17,13 +17,19 @@ class Admin {
     }
 
     public function add_settings_page() {
-        add_options_page( 'Rescue Sync', 'Rescue Sync', 'manage_options', 'rescue-sync', [ $this, 'render_settings_page' ] );
+        add_options_page(
+            __( 'Rescue Sync', 'rescuegroups-sync' ),
+            __( 'Rescue Sync', 'rescuegroups-sync' ),
+            'manage_options',
+            'rescue-sync',
+            [ $this, 'render_settings_page' ]
+        );
     }
 
     public function render_settings_page() {
         ?>
         <div class="wrap">
-            <h1><?php echo esc_html( 'Rescue Sync Settings' ); ?></h1>
+            <h1><?php echo esc_html__( 'Rescue Sync Settings', 'rescuegroups-sync' ); ?></h1>
             <form method="post" action="options.php">
                 <?php
                 settings_fields( 'rescue_sync' );
@@ -32,7 +38,7 @@ class Admin {
                 <table class="form-table" role="presentation">
                     <tr>
                         <th scope="row">
-                            <label for="rescue_sync_api_key"><?php echo esc_html( 'API Key' ); ?></label>
+                            <label for="rescue_sync_api_key"><?php echo esc_html__( 'API Key', 'rescuegroups-sync' ); ?></label>
                         </th>
                         <td>
                             <input name="rescue_sync_api_key" id="rescue_sync_api_key" type="text" value="<?php echo esc_attr( $api_key ); ?>" class="regular-text" />

--- a/rescuegroups-sync/includes/class-cpt.php
+++ b/rescuegroups-sync/includes/class-cpt.php
@@ -9,8 +9,8 @@ class CPT {
 
     public function register_cpt() {
         $labels = [
-            'name' => 'Adoptable Pets',
-            'singular_name' => 'Adoptable Pet',
+            'name' => __( 'Adoptable Pets', 'rescuegroups-sync' ),
+            'singular_name' => __( 'Adoptable Pet', 'rescuegroups-sync' ),
         ];
         $args = [
             'labels' => $labels,


### PR DESCRIPTION
## Summary
- hook custom post type labels into translation functions
- translate all strings on the Rescue Sync settings page

## Testing
- `php -l rescuegroups-sync/includes/class-cpt.php`
- `php -l rescuegroups-sync/includes/class-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_684a0764672c83269590b3e863f56477