### PR TITLE
Improve uninstall cleanup

### DIFF
--- a/rescuegroups-sync/uninstall.php
+++ b/rescuegroups-sync/uninstall.php
@@ -4,6 +4,23 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
     exit();
 }
 
+// Delete adoptable_pet posts and their meta.
+$posts = get_posts([
+    'post_type'   => 'adoptable_pet',
+    'post_status' => 'any',
+    'numberposts' => -1,
+    'fields'      => 'ids',
+]);
+
+foreach ( $posts as $post_id ) {
+    wp_delete_post( $post_id, true );
+}
+
+// Unschedule the cron event if it exists.
+$timestamp = wp_next_scheduled( 'rescue_sync_cron' );
+if ( $timestamp ) {
+    wp_unschedule_event( $timestamp, 'rescue_sync_cron' );
+}
+
 // Remove options.
 delete_option( 'rescue_sync_api_key' );
-// More cleanup to be added.


### PR DESCRIPTION
## Summary
- delete `adoptable_pet` posts and their metadata on uninstall
- unschedule the `rescue_sync_cron` event when uninstalling

## Testing
- `php -l rescuegroups-sync/uninstall.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a076a56ac83268444e8235bf8185e