### PR TITLE
Support multi page sync

### DIFF
--- a/rescuegroups-sync/includes/class-api-client.php
+++ b/rescuegroups-sync/includes/class-api-client.php
@@ -22,4 +22,28 @@ class API_Client {
         $data = json_decode( $body, true );
         return $data ? $data : [];
     }
+
+    /**
+     * Retrieve all available animals by iterating through each page.
+     *
+     * @return array Combined API response data.
+     */
+    public function get_all_available_animals() {
+        $page      = 1;
+        $all_data  = [ 'data' => [] ];
+
+        do {
+            $results = $this->get_available_animals( $page );
+
+            if ( isset( $results['data'] ) && is_array( $results['data'] ) ) {
+                $all_data['data'] = array_merge( $all_data['data'], $results['data'] );
+            } else {
+                break;
+            }
+
+            $page++;
+        } while ( ! empty( $results['data'] ) );
+
+        return $all_data;
+    }
 }

--- a/rescuegroups-sync/includes/class-sync.php
+++ b/rescuegroups-sync/includes/class-sync.php
@@ -41,7 +41,7 @@ class Sync {
         }
 
         $client  = new API_Client( $api_key );
-        $results = $client->get_available_animals();
+        $results = $client->get_all_available_animals();
 
         if ( empty( $results['data'] ) || ! is_array( $results['data'] ) ) {
             return;


### PR DESCRIPTION
## Summary
- add `get_all_available_animals()` that loads every page from the RescueGroups API
- call new method from the sync job

## Testing
- `php -l rescuegroups-sync/includes/class-api-client.php`
- `php -l rescuegroups-sync/includes/class-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_684a0767ff7c832686edc70a245d324f