### PR TITLE
Add translation loading on plugins_loaded

### DIFF
--- a/rescuegroups-sync/languages/README.md
+++ b/rescuegroups-sync/languages/README.md
@@ -1,0 +1,1 @@
+This directory stores translation files (.mo and .po) for the RescueGroups Sync plugin.

--- a/rescuegroups-sync/rescuegroups-sync.php
+++ b/rescuegroups-sync/rescuegroups-sync.php
@@ -25,7 +25,8 @@ define( 'RESCUE_SYNC_URL', plugin_dir_url( __FILE__ ) );
 function rescuegroups_sync_load_textdomain() {
     load_plugin_textdomain( 'rescuegroups-sync', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 }
-add_action( 'plugins_loaded', 'rescuegroups_sync_load_textdomain' );
+// Load translations before other components are initialized.
+add_action( 'plugins_loaded', 'rescuegroups_sync_load_textdomain', 1 );
 
 spl_autoload_register( function( $class ) {
     if ( 0 !== strpos( $class, 'RescueSync\\' ) ) {


### PR DESCRIPTION
## Summary
- add a `languages` directory for translation files
- load translations on `plugins_loaded` with priority 1 so they load before classes

## Testing
- `php -l rescuegroups-sync/rescuegroups-sync.php`

------
https://chatgpt.com/codex/tasks/task_e_684a0d4bf1d08326964620157536bb19