### PR TITLE
Load plugin text domain for translations

### DIFF
--- a/rescuegroups-sync/rescuegroups-sync.php
+++ b/rescuegroups-sync/rescuegroups-sync.php
@@ -22,11 +22,6 @@ define( 'RESCUE_SYNC_VERSION', '0.1.0' );
 define( 'RESCUE_SYNC_DIR', plugin_dir_path( __FILE__ ) );
 define( 'RESCUE_SYNC_URL', plugin_dir_url( __FILE__ ) );
 
-function rescuegroups_sync_load_textdomain() {
-    load_plugin_textdomain( 'rescuegroups-sync', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-}
-add_action( 'plugins_loaded', 'rescuegroups_sync_load_textdomain' );
-
 spl_autoload_register( function( $class ) {
     if ( 0 !== strpos( $class, 'RescueSync\\' ) ) {
         return;
@@ -49,6 +44,8 @@ register_deactivation_hook( __FILE__, [ 'RescueSync\\Sync', 'deactivate' ] );
 
 // Initialize components.
 add_action( 'plugins_loaded', function() {
+    load_plugin_textdomain( 'rescuegroups-sync', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+
     if ( class_exists( 'RescueSync\\CPT' ) ) {
         new RescueSync\CPT();
     }


### PR DESCRIPTION
## Summary
- load plugin translation files on the `plugins_loaded` hook
- add a placeholder `languages/` directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a0e531c6c83269642784cc1e3e70b