### PR TITLE
Fix uninstall cleanup and update readme

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -23,7 +23,8 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
 1. Obtain an API key from [RescueGroups.org](https://rescuegroups.org/).
 2. In the WordPress admin, go to **Rescue Sync** under **Settings**.
 3. Enter your API key and save the settings.
-4. Use the provided widgets or shortcode to display pets on your site.
+4. Choose how often the sync should run and optionally trigger a manual sync.
+5. Use the provided widgets or shortcode to display pets on your site.
 
 ## Shortcode Usage
 

--- a/rescuegroups-sync/uninstall.php
+++ b/rescuegroups-sync/uninstall.php
@@ -6,6 +6,10 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 // Remove options.
 delete_option( 'rescue_sync_api_key' );
+delete_option( 'rescue_sync_frequency' );
+delete_option( 'rescue_sync_last_sync' );
+delete_option( 'rescue_sync_last_status' );
+// More cleanup to be added.
 // Delete all adoptable_pet posts.
 $posts = get_posts(
     [


### PR DESCRIPTION
## Summary
- remove sync tracking options on uninstall
- document sync scheduling options in README

## Testing
- `php -l rescuegroups-sync/uninstall.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0f4c9c18832699d7e55877b4928e