### PR TITLE
Add TODO list from roadmap

### DIFF
--- a/rescuegroups-sync/TODO.md
+++ b/rescuegroups-sync/TODO.md
@@ -1,0 +1,20 @@
+# Development TODO
+
+The following tasks come from the plugin README:
+
+- Additional settings and customization options.
+- Gutenberg block support.
+- More extensive cleanup on uninstall.
+- Sorting functionality and filters (e.g., only show featured pets).
+- Optional "show random pet" feature (low priority).
+- Future updates will also remove custom posts and metadata created by the plugin so that your database is left clean.
+
+## Shortcode Idea
+
+Add a shortcode that counts pets by type and status:
+
+```
+[pet_count type="dog" status="available"]
+```
+
+The shortcode should accept `type` and `status` attributes to filter the count returned.


### PR DESCRIPTION
## Summary
- track roadmap tasks in a new TODO
- include uninstall cleanup reminder
- note shortcode idea for counting pets

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b38340c1c832687f3b753108ac403