### PR TITLE
Add Gutenberg block for adoptable pets

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -51,6 +51,12 @@ markdown
 Copy
 Edit
 
+## Block Usage
+
+An "Adoptable Pets" block is available in the Block Editor under the Widgets category.
+Add the block to any post or page and choose how many pets to display. Enable the
+"Only show featured" option to limit the list to featured animals.
+
 ## Available Fields
 
 Each synced pet stores the following meta fields:

--- a/rescuegroups-sync/build/block.js
+++ b/rescuegroups-sync/build/block.js
@@ -1,0 +1,44 @@
+( function( wp ) {
+    const { registerBlockType } = wp.blocks;
+    const { TextControl, CheckboxControl } = wp.components;
+    const { __ } = wp.i18n;
+    const { Fragment } = wp.element;
+
+    registerBlockType( 'rescue-sync/adoptable-pets', {
+        title: __( 'Adoptable Pets', 'rescuegroups-sync' ),
+        icon: 'pets',
+        category: 'widgets',
+        attributes: {
+            number: {
+                type: 'number',
+                default: 5
+            },
+            featured_only: {
+                type: 'boolean',
+                default: false
+            }
+        },
+        edit: function( props ) {
+            const { attributes, setAttributes } = props;
+            return wp.element.createElement(
+                Fragment,
+                null,
+                wp.element.createElement( 'p', null, __( 'This block displays a list of adoptable pets.', 'rescuegroups-sync' ) ),
+                wp.element.createElement( TextControl, {
+                    label: __( 'Number of pets', 'rescuegroups-sync' ),
+                    type: 'number',
+                    value: attributes.number,
+                    onChange: function( value ) { setAttributes( { number: parseInt( value, 10 ) || 0 } ); }
+                } ),
+                wp.element.createElement( CheckboxControl, {
+                    label: __( 'Only show featured', 'rescuegroups-sync' ),
+                    checked: attributes.featured_only,
+                    onChange: function( value ) { setAttributes( { featured_only: !! value } ); }
+                } )
+            );
+        },
+        save: function() {
+            return null;
+        }
+    } );
+} )( window.wp );

--- a/rescuegroups-sync/includes/class-blocks.php
+++ b/rescuegroups-sync/includes/class-blocks.php
@@ -1,0 +1,77 @@
+<?php
+namespace RescueSync;
+
+class Blocks {
+    public function __construct() {
+        add_action( 'init', [ $this, 'register_block' ] );
+    }
+
+    public function register_block() {
+        $handle = 'rescue-sync-block';
+        wp_register_script(
+            $handle,
+            RESCUE_SYNC_URL . 'build/block.js',
+            [ 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-components' ],
+            RESCUE_SYNC_VERSION,
+            true
+        );
+
+        register_block_type( 'rescue-sync/adoptable-pets', [
+            'editor_script'   => $handle,
+            'render_callback' => [ $this, 'render_block' ],
+            'attributes'      => [
+                'number' => [
+                    'type'    => 'number',
+                    'default' => 5,
+                ],
+                'featured_only' => [
+                    'type'    => 'boolean',
+                    'default' => false,
+                ],
+            ],
+        ] );
+    }
+
+    public function render_block( $atts = [] ) {
+        $atts = shortcode_atts(
+            [
+                'number'       => 5,
+                'featured_only'=> false,
+            ],
+            $atts,
+            'rescue-sync/adoptable-pets'
+        );
+
+        $query_args = [
+            'post_type'      => 'adoptable_pet',
+            'posts_per_page' => absint( $atts['number'] ),
+            'post_status'    => 'publish',
+        ];
+
+        if ( ! empty( $atts['featured_only'] ) ) {
+            $query_args['meta_query'] = [
+                [
+                    'key'   => '_rescue_sync_featured',
+                    'value' => '1',
+                ],
+            ];
+        }
+
+        $query = new \WP_Query( $query_args );
+        ob_start();
+        echo '<ul class="adoptable-pets-block">';
+        if ( $query->have_posts() ) {
+            while ( $query->have_posts() ) {
+                $query->the_post();
+                printf(
+                    '<li><a href="%s">%s</a></li>',
+                    esc_url( get_permalink() ),
+                    esc_html( get_the_title() )
+                );
+            }
+        }
+        echo '</ul>';
+        \wp_reset_postdata();
+        return ob_get_clean();
+    }
+}

--- a/rescuegroups-sync/rescuegroups-sync.php
+++ b/rescuegroups-sync/rescuegroups-sync.php
@@ -65,4 +65,7 @@ add_action( 'plugins_loaded', function() {
     if ( class_exists( 'RescueSync\\Shortcodes' ) ) {
         new RescueSync\Shortcodes();
     }
+    if ( class_exists( 'RescueSync\\Blocks' ) ) {
+        new RescueSync\Blocks();
+    }
 } );


### PR DESCRIPTION
## Summary
- add `RescueSync\Blocks` class and dynamic block renderer
- initialize block handler on `plugins_loaded`
- provide block JavaScript under `build/`
- document how to use the block in the README

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684b392be7448326a7dd48935a89ffb3