### PR TITLE
Add slug and query settings

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -22,11 +22,15 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
 
 1. Obtain an API key from [RescueGroups.org](https://rescuegroups.org/).  
 2. In the WordPress admin, go to **Rescue Sync** under **Settings**.  
-3. Enter your API key and save the settings.  
-4. Choose how often the sync should run and optionally trigger a manual sync.  
-5. Use the provided widgets or shortcodes to display pets on your site.  
-   - Posts can be flagged as **featured** or **hidden** from the post edit screen.  
+3. Enter your API key and save the settings.
+4. Choose how often the sync should run and optionally trigger a manual sync.
+5. Customize the adoptable pets archive slug and default query options.
+6. Use the provided widgets or shortcodes to display pets on your site.
+   - Posts can be flagged as **featured** or **hidden** from the post edit screen.
    - Widgets can optionally show featured pets first or exclusively.
+
+The archive slug controls the URL of the adoptable pets archive page (default `adopt`).
+Default query options set how many pets display and whether only featured pets are shown when no parameters are provided.
 
 ## Shortcode Usage
 

--- a/rescuegroups-sync/includes/class-admin.php
+++ b/rescuegroups-sync/includes/class-admin.php
@@ -24,6 +24,24 @@ class Admin {
 
         register_setting( 'rescue_sync', 'rescue_sync_last_sync', [ 'type' => 'integer' ] );
         register_setting( 'rescue_sync', 'rescue_sync_last_status', [ 'type' => 'string' ] );
+
+        register_setting( 'rescue_sync', 'rescue_sync_archive_slug', [
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_title',
+            'default'           => 'adopt',
+        ] );
+
+        register_setting( 'rescue_sync', 'rescue_sync_default_number', [
+            'type'              => 'integer',
+            'sanitize_callback' => 'absint',
+            'default'           => 5,
+        ] );
+
+        register_setting( 'rescue_sync', 'rescue_sync_default_featured', [
+            'type'              => 'boolean',
+            'sanitize_callback' => 'rest_sanitize_boolean',
+            'default'           => false,
+        ] );
     }
 
     public function sanitize_frequency( $value ) {
@@ -50,6 +68,9 @@ class Admin {
                 settings_fields( 'rescue_sync' );
                 $api_key   = Utils::get_option( 'api_key' );
                 $frequency = Utils::get_option( 'frequency', 'hourly' );
+                $slug      = Utils::get_option( 'archive_slug', 'adopt' );
+                $number    = Utils::get_option( 'default_number', 5 );
+                $featured  = Utils::get_option( 'default_featured', false );
                 $last_sync = Utils::get_option( 'last_sync', 0 );
                 $status    = Utils::get_option( 'last_status', '' );
                 ?>
@@ -79,6 +100,31 @@ class Admin {
                                 <option value="daily"     <?php selected( $frequency, 'daily' );     ?>><?php esc_html_e( 'Daily', 'rescuegroups-sync' );     ?></option>
                             </select>
                         </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="rescue_sync_archive_slug"><?php echo esc_html__( 'Archive Slug', 'rescuegroups-sync' ); ?></label>
+                        </th>
+                        <td>
+                            <input name="rescue_sync_archive_slug" id="rescue_sync_archive_slug" type="text" value="<?php echo esc_attr( $slug ); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="rescue_sync_default_number"><?php echo esc_html__( 'Default Number', 'rescuegroups-sync' ); ?></label>
+                        </th>
+                        <td>
+                            <input name="rescue_sync_default_number" id="rescue_sync_default_number" type="number" min="1" value="<?php echo esc_attr( $number ); ?>" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="rescue_sync_default_featured">
+                                <input name="rescue_sync_default_featured" id="rescue_sync_default_featured" type="checkbox" value="1" <?php checked( $featured ); ?> />
+                                <?php echo esc_html__( 'Featured Only by Default', 'rescuegroups-sync' ); ?>
+                            </label>
+                        </th>
+                        <td></td>
                     </tr>
                     <tr>
                         <th scope="row"><?php echo esc_html__( 'Last Sync', 'rescuegroups-sync' ); ?></th>

--- a/rescuegroups-sync/includes/class-cpt.php
+++ b/rescuegroups-sync/includes/class-cpt.php
@@ -13,12 +13,13 @@ class CPT {
             'name'          => __( 'Adoptable Pets', 'rescuegroups-sync' ),
             'singular_name' => __( 'Adoptable Pet', 'rescuegroups-sync' ),
         ];
+        $slug   = Utils::get_archive_slug();
         $args = [
             'labels'       => $labels,
             'public'       => true,
             'supports'     => [ 'title', 'editor', 'thumbnail' ],
             'has_archive'  => true,
-            'rewrite'      => [ 'slug' => 'adopt' ],
+            'rewrite'      => [ 'slug' => $slug ],
             'show_in_rest' => true,
         ];
         register_post_type( 'adoptable_pet', $args );

--- a/rescuegroups-sync/includes/class-shortcodes.php
+++ b/rescuegroups-sync/includes/class-shortcodes.php
@@ -13,10 +13,11 @@ class Shortcodes {
      * @return string HTML output.
      */
     public function adoptable_pets( $atts = [] ) {
+        $defaults = Utils::get_default_query_args();
         $atts = shortcode_atts(
             [
-                'number'       => 5,
-                'featured_only'=> false,
+                'number'       => $defaults['number'],
+                'featured_only'=> $defaults['featured_only'],
             ],
             $atts,
             'adoptable_pets'
@@ -31,8 +32,9 @@ class Shortcodes {
         if ( ! empty( $atts['featured_only'] ) ) {
             $query_args['meta_query'] = [
                 [
-                    'key'   => 'featured',
-                    'value' => '1',
+                    'key'     => '_rescue_sync_featured',
+                    'value'   => '1',
+                    'compare' => '=',
                 ],
             ];
         }

--- a/rescuegroups-sync/includes/class-sync.php
+++ b/rescuegroups-sync/includes/class-sync.php
@@ -32,7 +32,7 @@ class Sync {
             'public'      => true,
             'supports'    => [ 'title', 'editor', 'thumbnail' ],
             'has_archive' => true,
-            'rewrite'     => [ 'slug' => 'adopt' ],
+            'rewrite'     => [ 'slug' => Utils::get_archive_slug() ],
         ];
         register_post_type( 'adoptable_pet', $args );
 

--- a/rescuegroups-sync/includes/class-utils.php
+++ b/rescuegroups-sync/includes/class-utils.php
@@ -9,4 +9,27 @@ class Utils {
     public static function get_api_key() {
         return self::get_option( 'api_key' );
     }
+
+    /**
+     * Retrieve the archive slug for the adoptable_pet post type.
+     *
+     * @return string
+     */
+    public static function get_archive_slug() {
+        $slug = self::get_option( 'archive_slug', 'adopt' );
+        $slug = sanitize_title( $slug );
+        return $slug ? $slug : 'adopt';
+    }
+
+    /**
+     * Get default query arguments used by shortcodes and widgets.
+     *
+     * @return array
+     */
+    public static function get_default_query_args() {
+        return [
+            'number'       => absint( self::get_option( 'default_number', 5 ) ),
+            'featured_only'=> (bool) self::get_option( 'default_featured', false ),
+        ];
+    }
 }

--- a/rescuegroups-sync/includes/class-widgets.php
+++ b/rescuegroups-sync/includes/class-widgets.php
@@ -23,6 +23,9 @@ class Adoptable_Pets_Widget extends \WP_Widget {
     public function widget( $args, $instance ) {
         echo $args['before_widget'];
 
+        $defaults = Utils::get_default_query_args();
+        $instance = wp_parse_args( $instance, $defaults );
+
         $title = apply_filters( 'widget_title', $instance['title'] ?? '' );
         if ( $title ) {
             echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
@@ -30,7 +33,7 @@ class Adoptable_Pets_Widget extends \WP_Widget {
 
         $args_query = [
             'post_type'      => 'adoptable_pet',
-            'posts_per_page' => absint( $instance['number'] ?? 5 ),
+            'posts_per_page' => absint( $instance['number'] ),
             'post_status'    => 'publish',
         ];
         $query = new \WP_Query( array_merge( $args_query, $this->get_query_overrides( $instance ) ) );
@@ -86,8 +89,9 @@ class Adoptable_Pets_Widget extends \WP_Widget {
     }
 
     public function form( $instance ) {
+        $defaults = Utils::get_default_query_args();
         $title  = esc_attr( $instance['title'] ?? '' );
-        $number = absint( $instance['number'] ?? 5 );
+        $number = absint( $instance['number'] ?? $defaults['number'] );
         $featured_only  = ! empty( $instance['featured_only'] );
         $featured_first = ! empty( $instance['featured_first'] );
         ?>

--- a/rescuegroups-sync/uninstall.php
+++ b/rescuegroups-sync/uninstall.php
@@ -28,5 +28,8 @@ delete_option( 'rescue_sync_api_key' );
 delete_option( 'rescue_sync_frequency' );
 delete_option( 'rescue_sync_last_sync' );
 delete_option( 'rescue_sync_last_status' );
+delete_option( 'rescue_sync_archive_slug' );
+delete_option( 'rescue_sync_default_number' );
+delete_option( 'rescue_sync_default_featured' );
 
 // TODO: More extensive cleanup (e.g., remove metadata) can be added here.


### PR DESCRIPTION
## Summary
- allow customizing archive slug and default query options
- expose helper getters for new options
- use the archive slug when registering the CPT
- respect default query settings in shortcode and widget
- document the new settings

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b3929c4d483268c941ad96ba5290e