### PR TITLE
Improve uninstall cleanup

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -75,5 +75,8 @@ The plugin also registers `pet_species` and `pet_breed` taxonomies for better fi
 
 ## Uninstall
 
-Deleting the plugin from the **Plugins** screen triggers the `uninstall.php` script.  
-Currently this removes the stored API key option. Future updates will also remove custom posts and metadata created by the plugin so that your database is left clean.
+Deleting the plugin from the **Plugins** screen triggers the `uninstall.php` script.
+The uninstall routine now removes all `adoptable_pet` posts, deletes terms from
+the `pet_species` and `pet_breed` taxonomies, erases any metadata beginning with
+`_rescue_sync_`, clears scheduled sync events and deletes all plugin options.
+This leaves no orphaned data behind after removing the plugin.

--- a/rescuegroups-sync/uninstall.php
+++ b/rescuegroups-sync/uninstall.php
@@ -4,29 +4,52 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
     exit();
 }
 
+global $wpdb;
+
 // Delete all adoptable_pet posts and their meta.
-$posts = get_posts( [
-    'post_type'   => 'adoptable_pet',
-    'post_status' => 'any',
-    'numberposts' => -1,
-    'fields'      => 'ids',
-] );
+$posts = get_posts(
+    [
+        'post_type'   => 'adoptable_pet',
+        'post_status' => 'any',
+        'numberposts' => -1,
+        'fields'      => 'ids',
+    ]
+);
 
 foreach ( $posts as $post_id ) {
     wp_delete_post( $post_id, true );
 }
 
+// Remove custom taxonomy terms and relationships.
+$taxonomies = [ 'pet_species', 'pet_breed' ];
+foreach ( $taxonomies as $tax ) {
+    $tt_ids = $wpdb->get_col( $wpdb->prepare( "SELECT term_taxonomy_id FROM {$wpdb->term_taxonomy} WHERE taxonomy = %s", $tax ) );
+    if ( ! empty( $tt_ids ) ) {
+        $in_tt_ids = implode( ',', array_map( 'intval', $tt_ids ) );
+        $wpdb->query( "DELETE FROM {$wpdb->term_relationships} WHERE term_taxonomy_id IN ( $in_tt_ids )" );
+        $term_ids = $wpdb->get_col( "SELECT term_id FROM {$wpdb->term_taxonomy} WHERE term_taxonomy_id IN ( $in_tt_ids )" );
+        $wpdb->query( "DELETE FROM {$wpdb->term_taxonomy} WHERE term_taxonomy_id IN ( $in_tt_ids )" );
+        if ( ! empty( $term_ids ) ) {
+            $in_term_ids = implode( ',', array_map( 'intval', $term_ids ) );
+            $wpdb->query( "DELETE FROM {$wpdb->terms} WHERE term_id IN ( $in_term_ids )" );
+            if ( ! empty( $wpdb->termmeta ) ) {
+                $wpdb->query( "DELETE FROM {$wpdb->termmeta} WHERE term_id IN ( $in_term_ids )" );
+            }
+        }
+    }
+}
+
+// Delete any post meta starting with _rescue_sync_.
+$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->postmeta} WHERE meta_key LIKE %s", $wpdb->esc_like( '_rescue_sync_' ) . '%' ) );
+
 // Unschedule and clear all cron events.
-$timestamp = wp_next_scheduled( 'rescue_sync_cron' );
-if ( $timestamp ) {
+while ( ( $timestamp = wp_next_scheduled( 'rescue_sync_cron' ) ) ) {
     wp_unschedule_event( $timestamp, 'rescue_sync_cron' );
 }
 wp_clear_scheduled_hook( 'rescue_sync_cron' );
 
 // Remove plugin options.
-delete_option( 'rescue_sync_api_key' );
-delete_option( 'rescue_sync_frequency' );
-delete_option( 'rescue_sync_last_sync' );
-delete_option( 'rescue_sync_last_status' );
-
-// TODO: More extensive cleanup (e.g., remove metadata) can be added here.
+$options = $wpdb->get_col( $wpdb->prepare( "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s", $wpdb->esc_like( 'rescue_sync_' ) . '%' ) );
+foreach ( $options as $option ) {
+    delete_option( $option );
+}


### PR DESCRIPTION
## Summary
- perform thorough cleanup in uninstall.php
- document uninstall behavior in README

## Testing
- `php -l rescuegroups-sync/uninstall.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b392ccd088326922b77d37d740076