### PR TITLE
Add filtering options

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -27,6 +27,7 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
 5. Use the provided widgets or shortcodes to display pets on your site.  
    - Posts can be flagged as **featured** or **hidden** from the post edit screen.  
    - Widgets can optionally show featured pets first or exclusively.
+   - Species, breed and ordering options mirror the `[adoptable_pets]` shortcode.
 
 ## Shortcode Usage
 
@@ -40,8 +41,12 @@ Edit
 
 ### Parameters
 
-- `number` – Number of pets to show. Default is `5`.  
-- `featured_only` – Set to `1` to show only pets marked as featured.  
+- `number` – Number of pets to show. Default is `5`.
+- `featured_only` – Set to `1` to show only pets marked as featured.
+- `species` – Comma separated list of species slugs to include.
+- `breed` – Comma separated list of breed slugs to include.
+- `orderby` – Field to sort by (`date`, `title`, or `rand`).
+- `order` – Sort direction, either `ASC` or `DESC`.
 
 Example (eight featured pets):
 

--- a/rescuegroups-sync/includes/class-shortcodes.php
+++ b/rescuegroups-sync/includes/class-shortcodes.php
@@ -17,6 +17,10 @@ class Shortcodes {
             [
                 'number'       => 5,
                 'featured_only'=> false,
+                'species'      => '',
+                'breed'        => '',
+                'orderby'      => 'date',
+                'order'        => 'DESC',
             ],
             $atts,
             'adoptable_pets'
@@ -27,6 +31,33 @@ class Shortcodes {
             'posts_per_page' => absint( $atts['number'] ),
             'post_status'    => 'publish',
         ];
+
+        $tax_query = [];
+        if ( ! empty( $atts['species'] ) ) {
+            $tax_query[] = [
+                'taxonomy' => 'pet_species',
+                'field'    => 'slug',
+                'terms'    => array_map( 'sanitize_title', array_map( 'trim', explode( ',', $atts['species'] ) ) ),
+            ];
+        }
+        if ( ! empty( $atts['breed'] ) ) {
+            $tax_query[] = [
+                'taxonomy' => 'pet_breed',
+                'field'    => 'slug',
+                'terms'    => array_map( 'sanitize_title', array_map( 'trim', explode( ',', $atts['breed'] ) ) ),
+            ];
+        }
+        if ( ! empty( $tax_query ) ) {
+            $query_args['tax_query'] = $tax_query;
+        }
+
+        $orderby = strtolower( $atts['orderby'] );
+        if ( ! in_array( $orderby, [ 'date', 'title', 'rand' ], true ) ) {
+            $orderby = 'date';
+        }
+        $order = strtoupper( $atts['order'] ) === 'ASC' ? 'ASC' : 'DESC';
+        $query_args['orderby'] = $orderby;
+        $query_args['order']   = $order;
 
         if ( ! empty( $atts['featured_only'] ) ) {
             $query_args['meta_query'] = [

--- a/rescuegroups-sync/includes/class-widgets.php
+++ b/rescuegroups-sync/includes/class-widgets.php
@@ -60,34 +60,62 @@ class Adoptable_Pets_Widget extends \WP_Widget {
      * @return array Arguments to merge into WP_Query args.
      */
     protected function get_query_overrides( $instance ) {
-        if ( ! empty( $instance['featured_only'] ) ) {
-            return [
-                'meta_query' => [
-                    [
-                        'key'     => '_rescue_sync_featured',
-                        'value'   => '1',
-                        'compare' => '=',
-                    ],
-                ],
+        $args = [];
+
+        $tax_query = [];
+        if ( ! empty( $instance['species'] ) ) {
+            $tax_query[] = [
+                'taxonomy' => 'pet_species',
+                'field'    => 'slug',
+                'terms'    => array_map( 'sanitize_title', array_map( 'trim', explode( ',', $instance['species'] ) ) ),
             ];
         }
+        if ( ! empty( $instance['breed'] ) ) {
+            $tax_query[] = [
+                'taxonomy' => 'pet_breed',
+                'field'    => 'slug',
+                'terms'    => array_map( 'sanitize_title', array_map( 'trim', explode( ',', $instance['breed'] ) ) ),
+            ];
+        }
+        if ( ! empty( $tax_query ) ) {
+            $args['tax_query'] = $tax_query;
+        }
+
+        if ( ! empty( $instance['featured_only'] ) ) {
+            $args['meta_query'][] = [
+                'key'     => '_rescue_sync_featured',
+                'value'   => '1',
+                'compare' => '=',
+            ];
+        }
+
+        $orderby = strtolower( $instance['orderby'] ?? 'date' );
+        if ( ! in_array( $orderby, [ 'date', 'title', 'rand' ], true ) ) {
+            $orderby = 'date';
+        }
+        $order = strtoupper( $instance['order'] ?? 'DESC' ) === 'ASC' ? 'ASC' : 'DESC';
 
         if ( ! empty( $instance['featured_first'] ) ) {
-            return [
-                'meta_key' => '_rescue_sync_featured',
-                'orderby'  => [
-                    'meta_value_num' => 'DESC',
-                    'date'           => 'DESC',
-                ],
+            $args['meta_key'] = '_rescue_sync_featured';
+            $args['orderby']  = [
+                'meta_value_num' => 'DESC',
+                $orderby         => $order,
             ];
+        } else {
+            $args['orderby'] = $orderby;
+            $args['order']   = $order;
         }
 
-        return [];
+        return $args;
     }
 
     public function form( $instance ) {
         $title  = esc_attr( $instance['title'] ?? '' );
         $number = absint( $instance['number'] ?? 5 );
+        $species = esc_attr( $instance['species'] ?? '' );
+        $breed   = esc_attr( $instance['breed'] ?? '' );
+        $orderby = $instance['orderby'] ?? 'date';
+        $order   = $instance['order'] ?? 'DESC';
         $featured_only  = ! empty( $instance['featured_only'] );
         $featured_first = ! empty( $instance['featured_first'] );
         ?>
@@ -98,6 +126,29 @@ class Adoptable_Pets_Widget extends \WP_Widget {
         <p>
             <label for="<?php echo $this->get_field_id( 'number' ); ?>"><?php esc_html_e( 'Number of pets to show:', 'rescuegroups-sync' ); ?></label>
             <input id="<?php echo $this->get_field_id( 'number' ); ?>" name="<?php echo $this->get_field_name( 'number' ); ?>" type="number" min="1" value="<?php echo $number; ?>">
+        </p>
+        <p>
+            <label for="<?php echo $this->get_field_id( 'species' ); ?>"><?php esc_html_e( 'Species slugs (comma separated):', 'rescuegroups-sync' ); ?></label>
+            <input class="widefat" id="<?php echo $this->get_field_id( 'species' ); ?>" name="<?php echo $this->get_field_name( 'species' ); ?>" type="text" value="<?php echo $species; ?>">
+        </p>
+        <p>
+            <label for="<?php echo $this->get_field_id( 'breed' ); ?>"><?php esc_html_e( 'Breed slugs (comma separated):', 'rescuegroups-sync' ); ?></label>
+            <input class="widefat" id="<?php echo $this->get_field_id( 'breed' ); ?>" name="<?php echo $this->get_field_name( 'breed' ); ?>" type="text" value="<?php echo $breed; ?>">
+        </p>
+        <p>
+            <label for="<?php echo $this->get_field_id( 'orderby' ); ?>"><?php esc_html_e( 'Order by:', 'rescuegroups-sync' ); ?></label>
+            <select id="<?php echo $this->get_field_id( 'orderby' ); ?>" name="<?php echo $this->get_field_name( 'orderby' ); ?>">
+                <option value="date" <?php selected( $orderby, 'date' ); ?>><?php esc_html_e( 'Date', 'rescuegroups-sync' ); ?></option>
+                <option value="title" <?php selected( $orderby, 'title' ); ?>><?php esc_html_e( 'Title', 'rescuegroups-sync' ); ?></option>
+                <option value="rand" <?php selected( $orderby, 'rand' ); ?>><?php esc_html_e( 'Random', 'rescuegroups-sync' ); ?></option>
+            </select>
+        </p>
+        <p>
+            <label for="<?php echo $this->get_field_id( 'order' ); ?>"><?php esc_html_e( 'Order:', 'rescuegroups-sync' ); ?></label>
+            <select id="<?php echo $this->get_field_id( 'order' ); ?>" name="<?php echo $this->get_field_name( 'order' ); ?>">
+                <option value="DESC" <?php selected( $order, 'DESC' ); ?>>DESC</option>
+                <option value="ASC" <?php selected( $order, 'ASC' ); ?>>ASC</option>
+            </select>
         </p>
         <p>
             <label><input type="checkbox" id="<?php echo $this->get_field_id( 'featured_only' ); ?>" name="<?php echo $this->get_field_name( 'featured_only' ); ?>" value="1" <?php checked( $featured_only ); ?>> <?php esc_html_e( 'Only show featured pets', 'rescuegroups-sync' ); ?></label>
@@ -112,6 +163,10 @@ class Adoptable_Pets_Widget extends \WP_Widget {
         $instance = [];
         $instance['title']  = sanitize_text_field( $new_instance['title'] ?? '' );
         $instance['number'] = absint( $new_instance['number'] ?? 5 );
+        $instance['species'] = sanitize_text_field( $new_instance['species'] ?? '' );
+        $instance['breed']   = sanitize_text_field( $new_instance['breed'] ?? '' );
+        $instance['orderby'] = sanitize_key( $new_instance['orderby'] ?? 'date' );
+        $instance['order']   = strtoupper( $new_instance['order'] ?? 'DESC' ) === 'ASC' ? 'ASC' : 'DESC';
         $instance['featured_only']  = ! empty( $new_instance['featured_only'] ) ? 1 : 0;
         $instance['featured_first'] = ! empty( $new_instance['featured_first'] ) ? 1 : 0;
         return $instance;


### PR DESCRIPTION
## Summary
- extend `[adoptable_pets]` shortcode with species, breed and ordering
- allow the Adoptable Pets widget to use the same filters
- document new options in the README

## Testing
- `php -l rescuegroups-sync/includes/class-shortcodes.php` *(fails: command not found)*
- `php -l rescuegroups-sync/includes/class-widgets.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b392e8dd483269306c66af0baee0b