### PR TITLE
Add count_pets shortcode

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -51,6 +51,17 @@ markdown
 Copy
 Edit
 
+### Counting Pets
+
+Use `[count_pets]` to display how many pets match a species and status.
+`type` accepts a species slug and `status` defaults to `adoptable`.
+
+Example:
+
+```
+[count_pets type="dog" status="adoptable"]
+```
+
 ## Available Fields
 
 Each synced pet stores the following meta fields:

--- a/rescuegroups-sync/includes/class-shortcodes.php
+++ b/rescuegroups-sync/includes/class-shortcodes.php
@@ -4,6 +4,7 @@ namespace RescueSync;
 class Shortcodes {
     public function __construct() {
         add_shortcode( 'adoptable_pets', [ $this, 'adoptable_pets' ] );
+        add_shortcode( 'count_pets', [ $this, 'count_pets' ] );
     }
 
     /**
@@ -53,5 +54,67 @@ class Shortcodes {
         echo '</ul>';
         \wp_reset_postdata();
         return ob_get_clean();
+    }
+
+    /**
+     * Shortcode handler for [count_pets].
+     *
+     * @param array $atts Shortcode attributes.
+     * @return string Translated count text.
+     */
+    public function count_pets( $atts = [] ) {
+        $atts = shortcode_atts(
+            [
+                'type'   => '',
+                'status' => 'adoptable',
+            ],
+            $atts,
+            'count_pets'
+        );
+
+        $tax_query = [];
+        if ( $atts['type'] ) {
+            $tax_query[] = [
+                'taxonomy' => 'pet_species',
+                'field'    => 'slug',
+                'terms'    => sanitize_title( $atts['type'] ),
+            ];
+        }
+
+        $meta_query = [
+            [
+                'key'   => Sync::META_STATUS,
+                'value' => sanitize_text_field( $atts['status'] ),
+            ],
+        ];
+
+        $query = new \WP_Query([
+            'post_type'      => 'adoptable_pet',
+            'post_status'    => 'publish',
+            'fields'         => 'ids',
+            'posts_per_page' => -1,
+            'tax_query'      => $tax_query,
+            'meta_query'     => $meta_query,
+        ]);
+
+        $count = $query->found_posts;
+        \wp_reset_postdata();
+
+        $species_name = $atts['type'] ? sanitize_text_field( $atts['type'] ) : __( 'pets', 'rescuegroups-sync' );
+        $status_text  = sanitize_text_field( $atts['status'] );
+
+        return sprintf(
+            esc_html(
+                _n(
+                    'There is %1$d %2$s %3$s.',
+                    'There are %1$d %2$s %3$s.',
+                    $count,
+                    'rescuegroups-sync'
+                )
+            ),
+            $count,
+            $status_text,
+            $species_name
+        );
     }
 }

--- a/rescuegroups-sync/includes/class-sync.php
+++ b/rescuegroups-sync/includes/class-sync.php
@@ -8,6 +8,7 @@ class Sync {
     const META_AGE     = '_rescue_sync_age';
     const META_GENDER  = '_rescue_sync_gender';
     const META_PHOTOS  = '_rescue_sync_photos';
+    const META_STATUS  = '_rescue_sync_status';
 
     /**
      * Constructor.
@@ -87,6 +88,7 @@ class Sync {
             $breed   = $animal['attributes']['breedPrimary'] ?? ( $animal['attributes']['breedString'] ?? '' );
             $age     = $animal['attributes']['ageGroup'] ?? ( $animal['attributes']['ageString'] ?? '' );
             $gender  = $animal['attributes']['sex'] ?? '';
+            $status  = $animal['attributes']['status'] ?? ( $animal['attributes']['statusString'] ?? 'adoptable' );
 
             $photos = [];
             if ( isset( $animal['relationships']['pictures']['data'], $results['included']['pictures'] ) && is_array( $animal['relationships']['pictures']['data'] ) ) {
@@ -135,6 +137,7 @@ class Sync {
                 update_post_meta( $post_id, self::META_BREED, sanitize_text_field( $breed ) );
                 update_post_meta( $post_id, self::META_AGE, sanitize_text_field( $age ) );
                 update_post_meta( $post_id, self::META_GENDER, sanitize_text_field( $gender ) );
+                update_post_meta( $post_id, self::META_STATUS, sanitize_text_field( $status ) );
                 if ( ! empty( $photos ) ) {
                     update_post_meta( $post_id, self::META_PHOTOS, wp_json_encode( $photos ) );
                 }

--- a/rescuegroups-sync/languages/README.md
+++ b/rescuegroups-sync/languages/README.md
@@ -1,1 +1,2 @@
 This directory stores translation files (.mo and .po) for the RescueGroups Sync plugin.
+The `rescuegroups-sync.pot` template contains all translatable strings used by the plugin.

--- a/rescuegroups-sync/languages/rescuegroups-sync.pot
+++ b/rescuegroups-sync/languages/rescuegroups-sync.pot
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: RescueGroups Sync\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: includes/class-shortcodes.php
+msgid "There is %1$d %2$s %3$s."
+msgstr ""
+
+#: includes/class-shortcodes.php
+msgid "There are %1$d %2$s %3$s."
+msgstr ""
+
+#: includes/class-shortcodes.php
+msgid "pets"
+msgstr ""
+


### PR DESCRIPTION
## Summary
- extend Sync to save pet status
- add count_pets shortcode and translations
- document the new shortcode

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b393174cc83268a181d9b09181f36