### PR TITLE
Add random pet display options

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -24,9 +24,9 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
 2. In the WordPress admin, go to **Rescue Sync** under **Settings**.  
 3. Enter your API key and save the settings.  
 4. Choose how often the sync should run and optionally trigger a manual sync.  
-5. Use the provided widgets or shortcodes to display pets on your site.  
-   - Posts can be flagged as **featured** or **hidden** from the post edit screen.  
-   - Widgets can optionally show featured pets first or exclusively.
+5. Use the provided widgets or shortcodes to display pets on your site.
+   - Posts can be flagged as **featured** or **hidden** from the post edit screen.
+   - Widgets can optionally show featured pets first or exclusively, or display them randomly.
 
 ## Shortcode Usage
 
@@ -40,12 +40,15 @@ Edit
 
 ### Parameters
 
-- `number` – Number of pets to show. Default is `5`.  
-- `featured_only` – Set to `1` to show only pets marked as featured.  
+- `number` – Number of pets to show. Default is `5`.
+- `featured_only` – Set to `1` to show only pets marked as featured.
+- `random` – Set to `1` to show pets in random order.
 
 Example (eight featured pets):
 
 [adoptable_pets number="8" featured_only="1"]
+
+To display a single random pet you can use the `[random_pet]` shortcode which internally calls `[adoptable_pets random="1" number="1"]`.
 
 markdown
 Copy
@@ -69,9 +72,8 @@ The plugin also registers `pet_species` and `pet_breed` taxonomies for better fi
 
 - Additional settings and customization options.  
 - Gutenberg block support.  
-- More extensive cleanup on uninstall.  
-- Sorting functionality and filters (e.g., only show featured pets).  
-- Optional “show random pet” feature (low priority).
+- More extensive cleanup on uninstall.
+- Sorting functionality and filters (e.g., only show featured pets).
 
 ## Uninstall
 

--- a/rescuegroups-sync/includes/class-shortcodes.php
+++ b/rescuegroups-sync/includes/class-shortcodes.php
@@ -4,6 +4,7 @@ namespace RescueSync;
 class Shortcodes {
     public function __construct() {
         add_shortcode( 'adoptable_pets', [ $this, 'adoptable_pets' ] );
+        add_shortcode( 'random_pet', [ $this, 'random_pet' ] );
     }
 
     /**
@@ -17,6 +18,7 @@ class Shortcodes {
             [
                 'number'       => 5,
                 'featured_only'=> false,
+                'random'       => false,
             ],
             $atts,
             'adoptable_pets'
@@ -37,6 +39,10 @@ class Shortcodes {
             ];
         }
 
+        if ( ! empty( $atts['random'] ) ) {
+            $query_args['orderby'] = 'rand';
+        }
+
         $query = new \WP_Query( $query_args );
         ob_start();
         echo '<ul class="adoptable-pets-shortcode">';
@@ -53,5 +59,17 @@ class Shortcodes {
         echo '</ul>';
         \wp_reset_postdata();
         return ob_get_clean();
+    }
+
+    /**
+     * Display a single random pet.
+     *
+     * @param array $atts Optional shortcode attributes.
+     * @return string HTML output from adoptable_pets().
+     */
+    public function random_pet( $atts = [] ) {
+        $atts['number'] = 1;
+        $atts['random'] = true;
+        return $this->adoptable_pets( $atts );
     }
 }

--- a/rescuegroups-sync/includes/class-widgets.php
+++ b/rescuegroups-sync/includes/class-widgets.php
@@ -72,6 +72,10 @@ class Adoptable_Pets_Widget extends \WP_Widget {
             ];
         }
 
+        if ( ! empty( $instance['random'] ) ) {
+            return [ 'orderby' => 'rand' ];
+        }
+
         if ( ! empty( $instance['featured_first'] ) ) {
             return [
                 'meta_key' => '_rescue_sync_featured',
@@ -90,6 +94,7 @@ class Adoptable_Pets_Widget extends \WP_Widget {
         $number = absint( $instance['number'] ?? 5 );
         $featured_only  = ! empty( $instance['featured_only'] );
         $featured_first = ! empty( $instance['featured_first'] );
+        $random = ! empty( $instance['random'] );
         ?>
         <p>
             <label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php esc_html_e( 'Title:', 'rescuegroups-sync' ); ?></label>
@@ -105,6 +110,9 @@ class Adoptable_Pets_Widget extends \WP_Widget {
         <p>
             <label><input type="checkbox" id="<?php echo $this->get_field_id( 'featured_first' ); ?>" name="<?php echo $this->get_field_name( 'featured_first' ); ?>" value="1" <?php checked( $featured_first ); ?>> <?php esc_html_e( 'Show featured pets first', 'rescuegroups-sync' ); ?></label>
         </p>
+        <p>
+            <label><input type="checkbox" id="<?php echo $this->get_field_id( 'random' ); ?>" name="<?php echo $this->get_field_name( 'random' ); ?>" value="1" <?php checked( $random ); ?>> <?php esc_html_e( 'Display randomly', 'rescuegroups-sync' ); ?></label>
+        </p>
         <?php
     }
 
@@ -114,6 +122,7 @@ class Adoptable_Pets_Widget extends \WP_Widget {
         $instance['number'] = absint( $new_instance['number'] ?? 5 );
         $instance['featured_only']  = ! empty( $new_instance['featured_only'] ) ? 1 : 0;
         $instance['featured_first'] = ! empty( $new_instance['featured_first'] ) ? 1 : 0;
+        $instance['random']        = ! empty( $new_instance['random'] ) ? 1 : 0;
         return $instance;
     }
 }


### PR DESCRIPTION
## Summary
- enable `[random_pet]` shortcode and `random="1"` attribute
- let widgets optionally display pets in random order
- document usage of the new random features

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3932b0ac8326b2e3f139f9258fe0