### PR TITLE
Add sync manifest to skip unchanged animals

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -92,9 +92,13 @@ Each synced pet stores the following meta fields:
 - `_rescue_sync_breed` – Primary breed.  
 - `_rescue_sync_age` – Age group or string.  
 - `_rescue_sync_gender` – Gender/sex value.  
-- `_rescue_sync_photos` – JSON-encoded array of photo URLs.  
+- `_rescue_sync_photos` – JSON-encoded array of photo URLs.
 
 The plugin also registers `pet_species` and `pet_breed` taxonomies for better filtering.
+
+## Sync Manifest
+
+Each sync stores a manifest of imported animals in the `rescue_sync_manifest` option. The plugin compares incoming data against this manifest and skips updating posts when nothing has changed.
 
 ## Roadmap
 

--- a/rescuegroups-sync/includes/class-sync.php
+++ b/rescuegroups-sync/includes/class-sync.php
@@ -75,9 +75,20 @@ class Sync {
             return;
         }
 
+        $manifest = get_option( 'rescue_sync_manifest', [] );
+        if ( ! is_array( $manifest ) ) {
+            $manifest = [];
+        }
+
         foreach ( $results['data'] as $animal ) {
             $animal_id = isset( $animal['id'] ) ? intval( $animal['id'] ) : 0;
             if ( ! $animal_id ) {
+                continue;
+            }
+
+            $animal_hash = md5( wp_json_encode( $animal ) );
+
+            if ( isset( $manifest[ $animal_id ] ) && $manifest[ $animal_id ] === $animal_hash ) {
                 continue;
             }
 
@@ -148,9 +159,12 @@ class Sync {
                 if ( $breed ) {
                     wp_set_object_terms( $post_id, sanitize_text_field( $breed ), 'pet_breed', false );
                 }
+
+                $manifest[ $animal_id ] = $animal_hash;
             }
         }
 
+        update_option( 'rescue_sync_manifest', $manifest );
         update_option( 'rescue_sync_last_sync', current_time( 'timestamp' ) );
         update_option( 'rescue_sync_last_status', 'success' );
     }


### PR DESCRIPTION
## Summary
- track imported animal IDs and hashes in a new `rescue_sync_manifest` option
- skip animals that haven't changed before inserting posts
- document the manifest in the README

## Testing
- `php -l rescuegroups-sync/includes/class-sync.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b42a48f6883268626408d4b1cb775