### PR TITLE
Add manifest reset controls

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -24,8 +24,9 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
 2. In the WordPress admin, go to **Rescue Sync** under **Settings**.  
 3. Enter your API key and save the settings.
 4. Choose how often the sync should run and optionally trigger a manual sync.
-5. Customize the adoptable pets archive slug and default query options.
-6. Use the provided widgets or shortcodes to display pets on your site.
+5. Use the **Reset Manifest** button to clear the stored ID list if needed.
+6. Customize the adoptable pets archive slug and default query options.
+7. Use the provided widgets or shortcodes to display pets on your site.
    - Posts can be flagged as **featured** or **hidden** from the post edit screen.
    - Widgets can optionally show featured pets first or exclusively.
    - Species, breed and ordering options mirror the `[adoptable_pets]` shortcode.


### PR DESCRIPTION
## Summary
- add Reset Manifest button in the admin settings
- register manifest options and add reset handler
- document new feature in README

## Testing
- `php -l rescuegroups-sync/includes/class-admin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b42a6ac348326beb7cd6394d470d0