### PR TITLE
Add fetch limit option for sync

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -24,8 +24,9 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
 2. In the WordPress admin, go to **Rescue Sync** under **Settings**.  
 3. Enter your API key and save the settings.
 4. Choose how often the sync should run and optionally trigger a manual sync.
-5. Customize the adoptable pets archive slug and default query options.
-6. Use the provided widgets or shortcodes to display pets on your site.
+5. Set how many animals are fetched during each sync (default `100`).
+6. Customize the adoptable pets archive slug and default query options.
+7. Use the provided widgets or shortcodes to display pets on your site.
    - Posts can be flagged as **featured** or **hidden** from the post edit screen.
    - Widgets can optionally show featured pets first or exclusively.
    - Species, breed and ordering options mirror the `[adoptable_pets]` shortcode.

--- a/rescuegroups-sync/includes/class-admin.php
+++ b/rescuegroups-sync/includes/class-admin.php
@@ -42,6 +42,12 @@ class Admin {
             'sanitize_callback' => 'rest_sanitize_boolean',
             'default'           => false,
         ] );
+
+        register_setting( 'rescue_sync', 'rescue_sync_fetch_limit', [
+            'type'              => 'integer',
+            'sanitize_callback' => 'absint',
+            'default'           => 100,
+        ] );
     }
 
     public function sanitize_frequency( $value ) {
@@ -71,6 +77,7 @@ class Admin {
                 $slug      = Utils::get_option( 'archive_slug', 'adopt' );
                 $number    = Utils::get_option( 'default_number', 5 );
                 $featured  = Utils::get_option( 'default_featured', false );
+                $limit     = Utils::get_option( 'fetch_limit', 100 );
                 $last_sync = Utils::get_option( 'last_sync', 0 );
                 $status    = Utils::get_option( 'last_status', '' );
                 ?>
@@ -99,6 +106,14 @@ class Admin {
                                 <option value="twicedaily"<?php selected( $frequency, 'twicedaily'); ?>><?php esc_html_e( 'Twice Daily', 'rescuegroups-sync'); ?></option>
                                 <option value="daily"     <?php selected( $frequency, 'daily' );     ?>><?php esc_html_e( 'Daily', 'rescuegroups-sync' );     ?></option>
                             </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="rescue_sync_fetch_limit"><?php echo esc_html__( 'Fetch Limit', 'rescuegroups-sync' ); ?></label>
+                        </th>
+                        <td>
+                            <input name="rescue_sync_fetch_limit" id="rescue_sync_fetch_limit" type="number" min="1" value="<?php echo esc_attr( $limit ); ?>" />
                         </td>
                     </tr>
                     <tr>

--- a/rescuegroups-sync/includes/class-api-client.php
+++ b/rescuegroups-sync/includes/class-api-client.php
@@ -8,8 +8,9 @@ class API_Client {
         $this->api_key = $api_key;
     }
 
-    public function get_available_animals( $page = 1 ) {
-        $url  = 'https://api.rescuegroups.org/v5/public/animals/search/available?limit=100&page=' . intval( $page );
+    public function get_available_animals( $page = 1, $per_page = 100 ) {
+        $per_page = max( 1, min( 100, intval( $per_page ) ) );
+        $url  = 'https://api.rescuegroups.org/v5/public/animals/search/available?limit=' . $per_page . '&page=' . intval( $page );
         $url .= '&include=pictures,species,breeds';
         $response = wp_remote_get( $url, [
             'headers' => [ 'x-api-key' => $this->api_key ],
@@ -27,14 +28,20 @@ class API_Client {
     /**
      * Retrieve all available animals by iterating through each page.
      *
+     * @param int $limit Maximum number of animals to fetch. 0 for unlimited.
      * @return array Combined API response data.
      */
-    public function get_all_available_animals() {
-        $page      = 1;
-        $all_data  = [ 'data' => [] ];
+    public function get_all_available_animals( $limit = 0 ) {
+        $page     = 1;
+        $all_data = [ 'data' => [] ];
 
         do {
-            $results = $this->get_available_animals( $page );
+            $remaining = $limit > 0 ? $limit - count( $all_data['data'] ) : 100;
+            if ( $limit > 0 && $remaining <= 0 ) {
+                break;
+            }
+
+            $results = $this->get_available_animals( $page, $remaining );
 
             if ( isset( $results['data'] ) && is_array( $results['data'] ) ) {
                 $all_data['data'] = array_merge( $all_data['data'], $results['data'] );
@@ -43,7 +50,11 @@ class API_Client {
             }
 
             $page++;
-        } while ( ! empty( $results['data'] ) );
+        } while ( ! empty( $results['data'] ) && ( $limit <= 0 || count( $all_data['data'] ) < $limit ) );
+
+        if ( $limit > 0 && count( $all_data['data'] ) > $limit ) {
+            $all_data['data'] = array_slice( $all_data['data'], 0, $limit );
+        }
 
         return $all_data;
     }

--- a/rescuegroups-sync/includes/class-sync.php
+++ b/rescuegroups-sync/includes/class-sync.php
@@ -67,7 +67,8 @@ class Sync {
         }
 
         $client  = new API_Client( $api_key );
-        $results = $client->get_all_available_animals();
+        $limit   = absint( Utils::get_option( 'fetch_limit', 100 ) );
+        $results = $client->get_all_available_animals( $limit );
 
         if ( empty( $results['data'] ) || ! is_array( $results['data'] ) ) {
             update_option( 'rescue_sync_last_sync', current_time( 'timestamp' ) );


### PR DESCRIPTION
## Summary
- add `rescue_sync_fetch_limit` setting to limit number of animals synced
- respect limit in `API_Client::get_all_available_animals`
- expose fetch limit option on settings page
- document new option in README

## Testing
- `php -l rescuegroups-sync/includes/class-api-client.php`
- `php -l rescuegroups-sync/includes/class-admin.php`
- `php -l rescuegroups-sync/includes/class-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_684b42a79c9483268c3490131888f5df