### PR TITLE
Add API filter options

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -24,7 +24,9 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
 2. In the WordPress admin, go to **Rescue Sync** under **Settings**.  
 3. Enter your API key and save the settings.
 4. Choose how often the sync should run and optionally trigger a manual sync.
-5. Customize the adoptable pets archive slug and default query options.
+5. Customize the adoptable pets archive slug and default query options. The
+   settings page also lets you specify optional species and status filters
+   that limit which animals are synced from the API.
 6. Use the provided widgets or shortcodes to display pets on your site.
    - Posts can be flagged as **featured** or **hidden** from the post edit screen.
    - Widgets can optionally show featured pets first or exclusively.

--- a/rescuegroups-sync/includes/class-admin.php
+++ b/rescuegroups-sync/includes/class-admin.php
@@ -42,6 +42,18 @@ class Admin {
             'sanitize_callback' => 'rest_sanitize_boolean',
             'default'           => false,
         ] );
+
+        register_setting( 'rescue_sync', 'rescue_sync_species_filter', [
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => '',
+        ] );
+
+        register_setting( 'rescue_sync', 'rescue_sync_status_filter', [
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => '',
+        ] );
     }
 
     public function sanitize_frequency( $value ) {
@@ -66,13 +78,15 @@ class Admin {
             <form method="post" action="options.php">
                 <?php
                 settings_fields( 'rescue_sync' );
-                $api_key   = Utils::get_option( 'api_key' );
-                $frequency = Utils::get_option( 'frequency', 'hourly' );
-                $slug      = Utils::get_option( 'archive_slug', 'adopt' );
-                $number    = Utils::get_option( 'default_number', 5 );
-                $featured  = Utils::get_option( 'default_featured', false );
-                $last_sync = Utils::get_option( 'last_sync', 0 );
-                $status    = Utils::get_option( 'last_status', '' );
+                $api_key        = Utils::get_option( 'api_key' );
+                $frequency      = Utils::get_option( 'frequency', 'hourly' );
+                $slug           = Utils::get_option( 'archive_slug', 'adopt' );
+                $number         = Utils::get_option( 'default_number', 5 );
+                $featured       = Utils::get_option( 'default_featured', false );
+                $species_filter = Utils::get_option( 'species_filter', '' );
+                $status_filter  = Utils::get_option( 'status_filter', '' );
+                $last_sync      = Utils::get_option( 'last_sync', 0 );
+                $status         = Utils::get_option( 'last_status', '' );
                 ?>
                 <table class="form-table" role="presentation">
                     <tr>
@@ -99,6 +113,22 @@ class Admin {
                                 <option value="twicedaily"<?php selected( $frequency, 'twicedaily'); ?>><?php esc_html_e( 'Twice Daily', 'rescuegroups-sync'); ?></option>
                                 <option value="daily"     <?php selected( $frequency, 'daily' );     ?>><?php esc_html_e( 'Daily', 'rescuegroups-sync' );     ?></option>
                             </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="rescue_sync_species_filter"><?php echo esc_html__( 'Species Filter', 'rescuegroups-sync' ); ?></label>
+                        </th>
+                        <td>
+                            <input name="rescue_sync_species_filter" id="rescue_sync_species_filter" type="text" value="<?php echo esc_attr( $species_filter ); ?>" class="regular-text" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="rescue_sync_status_filter"><?php echo esc_html__( 'Status Filter', 'rescuegroups-sync' ); ?></label>
+                        </th>
+                        <td>
+                            <input name="rescue_sync_status_filter" id="rescue_sync_status_filter" type="text" value="<?php echo esc_attr( $status_filter ); ?>" class="regular-text" />
                         </td>
                     </tr>
                     <tr>

--- a/rescuegroups-sync/includes/class-api-client.php
+++ b/rescuegroups-sync/includes/class-api-client.php
@@ -8,9 +8,28 @@ class API_Client {
         $this->api_key = $api_key;
     }
 
-    public function get_available_animals( $page = 1 ) {
-        $url  = 'https://api.rescuegroups.org/v5/public/animals/search/available?limit=100&page=' . intval( $page );
-        $url .= '&include=pictures,species,breeds';
+    /**
+     * Fetch a page of available animals.
+     *
+     * @param int   $page   Page number to request.
+     * @param array $params Optional query parameters.
+     * @return array        Decoded API response or empty array on failure.
+     */
+    public function get_available_animals( $page = 1, $params = [] ) {
+        $base  = 'https://api.rescuegroups.org/v5/public/animals/search/available';
+        $query = [
+            'limit'   => 100,
+            'page'    => intval( $page ),
+            'include' => 'pictures,species,breeds',
+        ];
+
+        foreach ( (array) $params as $key => $value ) {
+            if ( '' !== $value && null !== $value ) {
+                $query[ $key ] = $value;
+            }
+        }
+
+        $url = add_query_arg( $query, $base );
         $response = wp_remote_get( $url, [
             'headers' => [ 'x-api-key' => $this->api_key ],
         ] );
@@ -29,12 +48,12 @@ class API_Client {
      *
      * @return array Combined API response data.
      */
-    public function get_all_available_animals() {
+    public function get_all_available_animals( $params = [] ) {
         $page      = 1;
         $all_data  = [ 'data' => [] ];
 
         do {
-            $results = $this->get_available_animals( $page );
+            $results = $this->get_available_animals( $page, $params );
 
             if ( isset( $results['data'] ) && is_array( $results['data'] ) ) {
                 $all_data['data'] = array_merge( $all_data['data'], $results['data'] );

--- a/rescuegroups-sync/includes/class-sync.php
+++ b/rescuegroups-sync/includes/class-sync.php
@@ -67,7 +67,18 @@ class Sync {
         }
 
         $client  = new API_Client( $api_key );
-        $results = $client->get_all_available_animals();
+
+        $params = [];
+        $species_filter = Utils::get_option( 'species_filter', '' );
+        $status_filter  = Utils::get_option( 'status_filter', '' );
+        if ( $species_filter ) {
+            $params['species'] = $species_filter;
+        }
+        if ( $status_filter ) {
+            $params['status'] = $status_filter;
+        }
+
+        $results = $client->get_all_available_animals( $params );
 
         if ( empty( $results['data'] ) || ! is_array( $results['data'] ) ) {
             update_option( 'rescue_sync_last_sync', current_time( 'timestamp' ) );


### PR DESCRIPTION
## Summary
- allow optional query params when requesting animals
- let site owners specify API filters for species and status
- pass those filters through Sync
- document the new filters in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b42a9b7fc832683960d71a0e40b54