### PR TITLE
Remove leftover code fences

### DIFF
--- a/rescuegroups-sync/includes/class-widgets.php
+++ b/rescuegroups-sync/includes/class-widgets.php
@@ -1,4 +1,3 @@
-```php
 <?php
 namespace RescueSync;
 
@@ -240,5 +239,3 @@ class Adoptable_Pets_Widget extends \WP_Widget {
         $instance['random']        = ! empty( $new_instance['random'] ) ? 1 : 0;
         return $instance;
     }
-}
-```


### PR DESCRIPTION
## Summary
- clean up `class-widgets.php` by removing erroneous markdown code fences

## Testing
- `php -l rescuegroups-sync/includes/class-widgets.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b42ac7d88832688471f0457088bc9