### PR TITLE
Implement cron rescheduling and translations

### DIFF
--- a/rescuegroups-sync/languages/rescuegroups-sync.pot
+++ b/rescuegroups-sync/languages/rescuegroups-sync.pot
@@ -1,19 +1,186 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: RescueGroups Sync\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-12 22:29+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: includes/class-shortcodes.php
-msgid "There is %1$d %2$s %3$s."
+#: src/Widgets/AdoptablePets.php:11 src/CPT/Register.php:20
+msgid "Adoptable Pets"
 msgstr ""
 
-#: includes/class-shortcodes.php
-msgid "There are %1$d %2$s %3$s."
+#: src/Widgets/AdoptablePets.php:11
+msgid "Displays latest adoptable pets."
 msgstr ""
 
-#: includes/class-shortcodes.php
+#: src/Widgets/AdoptablePets.php:99
+msgid "Title:"
+msgstr ""
+
+#: src/Widgets/AdoptablePets.php:103
+msgid "Number of pets to show:"
+msgstr ""
+
+#: src/Widgets/AdoptablePets.php:107
+msgid "Species slugs (comma separated):"
+msgstr ""
+
+#: src/Widgets/AdoptablePets.php:111
+msgid "Breed slugs (comma separated):"
+msgstr ""
+
+#: src/Widgets/AdoptablePets.php:115
+msgid "Order by:"
+msgstr ""
+
+#: src/Widgets/AdoptablePets.php:117
+msgid "Date"
+msgstr ""
+
+#: src/Widgets/AdoptablePets.php:118
+msgid "Title"
+msgstr ""
+
+#: src/Widgets/AdoptablePets.php:119
+msgid "Random"
+msgstr ""
+
+#: src/Widgets/AdoptablePets.php:123
+msgid "Order:"
+msgstr ""
+
+#: src/Widgets/AdoptablePets.php:130
+msgid "Only show featured pets"
+msgstr ""
+
+#: src/Widgets/AdoptablePets.php:133
+msgid "Show featured pets first"
+msgstr ""
+
+#: src/Widgets/AdoptablePets.php:136
+msgid "Display randomly"
+msgstr ""
+
+#: src/Admin/ActionHandlers.php:26 src/Admin/ActionHandlers.php:37
+msgid "Unauthorized"
+msgstr ""
+
+#: src/Admin/MetaBoxRegistrar.php:20
+msgid "Rescue Sync Options"
+msgstr ""
+
+#: src/Admin/MetaBoxRegistrar.php:33
+msgid "Featured"
+msgstr ""
+
+#: src/Admin/MetaBoxRegistrar.php:34
+msgid "Hidden"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:44
+msgid "Rescue Sync"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:53
+msgid "Rescue Sync Settings"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:71
+msgid "API Key"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:79
+msgid "Sync Frequency"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:83
+msgid "Hourly"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:84
+msgid "Twice Daily"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:85
+msgid "Daily"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:91
+msgid "Fetch Limit"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:99
+msgid "Species Filter"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:107
+msgid "Status Filter"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:115
+msgid "Archive Slug"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:123
+msgid "Default Number"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:133
+msgid "Featured Only by Default"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:139
+msgid "Last Sync"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:145
+msgid "Never"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:159
+msgid "Run Sync Now"
+msgstr ""
+
+#: src/Admin/SettingsPage.php:164
+msgid "Reset Manifest"
+msgstr ""
+
+#: src/Shortcodes/Handlers.php:125
 msgid "pets"
 msgstr ""
 
+#: src/Shortcodes/Handlers.php:127
+#, php-format
+msgid "There is %1$d %2$s %3$s."
+msgid_plural "There are %1$d %2$s %3$s."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/CPT/Register.php:21
+msgid "Adoptable Pet"
+msgstr ""
+
+#: src/CPT/Register.php:52 src/CPT/Register.php:53
+msgid "Species"
+msgstr ""
+
+#: src/CPT/Register.php:65
+msgid "Breeds"
+msgstr ""
+
+#: src/CPT/Register.php:66
+msgid "Breed"
+msgstr ""

--- a/rescuegroups-sync/src/Blocks/AdoptableBlock.php
+++ b/rescuegroups-sync/src/Blocks/AdoptableBlock.php
@@ -12,6 +12,7 @@ class AdoptableBlock {
     public function registerBlock() {
         $handle = 'rescue-sync-block';
         wp_register_script( $handle, RESCUE_SYNC_URL . 'build/block.js', [ 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-components' ], RESCUE_SYNC_VERSION, true );
+        wp_set_script_translations( $handle, 'rescuegroups-sync', RESCUE_SYNC_DIR . 'languages' );
         register_block_type( 'rescue-sync/adoptable-pets', [
             'editor_script'   => $handle,
             'render_callback' => [ $this, 'renderBlock' ],

--- a/rescuegroups-sync/src/Plugin.php
+++ b/rescuegroups-sync/src/Plugin.php
@@ -21,6 +21,8 @@ class Plugin {
         $client  = new Client( $api_key );
         $runner  = new Runner( $client );
 
+        add_action( 'update_option_rescue_sync_frequency', [ Runner::class, 'updateSchedule' ], 10, 2 );
+
         $settingsRegistrar = new SettingsRegistrar();
         ( new CPTRegister() )->register();
         ( new MetaBoxRegistrar() )->register();

--- a/rescuegroups-sync/src/Sync/Runner.php
+++ b/rescuegroups-sync/src/Sync/Runner.php
@@ -40,9 +40,19 @@ class Runner {
 
     /** Clear cron on deactivation. */
     public static function deactivate() : void {
-        $timestamp = wp_next_scheduled( 'rescue_sync_cron' );
-        if ( $timestamp ) {
-            wp_unschedule_event( $timestamp, 'rescue_sync_cron' );
+        wp_clear_scheduled_hook( 'rescue_sync_cron' );
+    }
+
+    /**
+     * Reschedule cron when the frequency option changes.
+     *
+     * @param string $old_value Previous value.
+     * @param string $value     New value.
+     */
+    public static function updateSchedule( $old_value, $value ) : void {
+        wp_clear_scheduled_hook( 'rescue_sync_cron' );
+        if ( $value ) {
+            wp_schedule_event( time(), sanitize_text_field( $value ), 'rescue_sync_cron' );
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust deactivation to clear all scheduled events
- reschedule cron job when `rescue_sync_frequency` updates
- load translations for the block script
- regenerate `rescuegroups-sync.pot`

## Testing
- `xgettext --language=PHP --from-code=UTF-8 --add-comments=translators --force-po --keyword=__ --keyword=_e --keyword=_x:1,2c --keyword=_n:1,2 --keyword=_nx:1,2,4 --keyword=esc_attr__ --keyword=esc_attr_e --keyword=esc_attr_x:1,2c --keyword=esc_html__ --keyword=esc_html_e --keyword=esc_html_x:1,2c -o languages/rescuegroups-sync.pot $(find src -name '*.php')`

------
https://chatgpt.com/codex/tasks/task_e_684b53e5985083269a99d7b82acbf0ba