### PR TITLE
Improve sync profiling and raw data handling

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -24,14 +24,17 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
 2. In the WordPress admin, go to **Rescue Sync** under **Settings**.  
 3. Enter your API key and save.  
 4. Choose how often to sync and/or click **Run Sync Now** for a manual sync.  
-5. Set **Fetch Limit** (how many animals to pull per run; default `100`).  
-6. Optionally specify **Species** and **Status** filters to limit which pets are synced.  
-7. Use **Reset Manifest** to clear the stored ID list and re-sync everything.  
-8. Customize your **Archive Slug** (default `adopt`) and **Default Query Options** (number of pets, featured-only, etc.).  
-9. Use the widgets/shortcodes to display pets:  
+5. Set **Fetch Limit** (how many animals to pull per run; default `100`).
+6. Optionally specify **Species** and **Status** filters to limit which pets are synced.
+7. Enable **Store Raw API Data** if you want a copy of each record kept in post meta. Set the retention period in days.
+8. Use **Reset Manifest** to clear the stored ID list and re-sync everything.
+9. Customize your **Archive Slug** (default `adopt`) and **Default Query Options** (number of pets, featured-only, etc.).
+10. Use the widgets/shortcodes to display pets:
    - Flag posts **Featured** or **Hidden** in the post editor  
-   - Widgets can show featured-first or featured-only  
-   - The `[adoptable_pets]` shortcode supports `species`, `breed`, `orderby`, and `order` parameters  
+   - Widgets can show featured-first or featured-only
+   - The `[adoptable_pets]` shortcode supports `species`, `breed`, `orderby`, and `order` parameters
+
+The settings page also displays the runtime and peak memory usage from the last sync to help diagnose performance issues.
 
 The archive slug controls the URL of the adoptable pets archive page (default `adopt`).
 Default query options set how many pets display and whether only featured pets are shown when no parameters are provided.
@@ -89,9 +92,9 @@ Add the block to any post or page and choose how many pets to display. Enable th
 
 Each synced pet stores the following meta fields:
 
-- `rescuegroups_id` – RescueGroups.org identifier.  
-- `rescuegroups_raw` – Raw API response for the record.  
-- `_rescue_sync_species` – Species name.  
+- `rescuegroups_id` – RescueGroups.org identifier.
+- `rescuegroups_raw` – (optional) Trimmed API data when **Store Raw API Data** is enabled.
+- `_rescue_sync_species` – Species name.
 - `_rescue_sync_breed` – Primary breed.  
 - `_rescue_sync_age` – Age group or string.  
 - `_rescue_sync_gender` – Gender/sex value.  

--- a/rescuegroups-sync/src/Admin/SettingsPage.php
+++ b/rescuegroups-sync/src/Admin/SettingsPage.php
@@ -62,8 +62,12 @@ class SettingsPage {
                 $limit          = Options::get( 'fetch_limit', 100 );
                 $species_filter = Options::get( 'species_filter', '' );
                 $status_filter  = Options::get( 'status_filter', '' );
+                $store_raw      = Options::get( 'store_raw', false );
+                $raw_retention  = Options::get( 'raw_retention', 30 );
                 $last_sync      = Options::get( 'last_sync', 0 );
                 $status         = Options::get( 'last_status', '' );
+                $last_runtime   = Options::get( 'last_runtime', '' );
+                $last_memory    = Options::get( 'last_memory', '' );
                 ?>
                 <table class="form-table" role="presentation">
                     <tr>
@@ -92,6 +96,23 @@ class SettingsPage {
                         </th>
                         <td>
                             <input name="rescue_sync_fetch_limit" id="rescue_sync_fetch_limit" type="number" min="1" value="<?php echo esc_attr( $limit ); ?>" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="rescue_sync_store_raw">
+                                <input name="rescue_sync_store_raw" id="rescue_sync_store_raw" type="checkbox" value="1" <?php checked( $store_raw ); ?> />
+                                <?php echo esc_html__( 'Store Raw API Data', 'rescuegroups-sync' ); ?>
+                            </label>
+                        </th>
+                        <td></td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="rescue_sync_raw_retention"><?php echo esc_html__( 'Raw Data Retention (days)', 'rescuegroups-sync' ); ?></label>
+                        </th>
+                        <td>
+                            <input name="rescue_sync_raw_retention" id="rescue_sync_raw_retention" type="number" min="0" value="<?php echo esc_attr( $raw_retention ); ?>" />
                         </td>
                     </tr>
                     <tr>
@@ -149,6 +170,14 @@ class SettingsPage {
                             }
                             ?>
                         </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php echo esc_html__( 'Last Run Time', 'rescuegroups-sync' ); ?></th>
+                        <td><?php echo esc_html( $last_runtime ); ?></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php echo esc_html__( 'Last Peak Memory', 'rescuegroups-sync' ); ?></th>
+                        <td><?php echo esc_html( $last_memory ); ?></td>
                     </tr>
                 </table>
                 <?php submit_button(); ?>

--- a/rescuegroups-sync/src/Admin/SettingsRegistrar.php
+++ b/rescuegroups-sync/src/Admin/SettingsRegistrar.php
@@ -47,6 +47,28 @@ class SettingsRegistrar {
             'default'           => 100,
         ] );
 
+        register_setting( 'rescue_sync', 'rescue_sync_store_raw', [
+            'type'              => 'boolean',
+            'sanitize_callback' => 'rest_sanitize_boolean',
+            'default'           => false,
+        ] );
+
+        register_setting( 'rescue_sync', 'rescue_sync_raw_retention', [
+            'type'              => 'integer',
+            'sanitize_callback' => 'absint',
+            'default'           => 30,
+        ] );
+
+        register_setting( 'rescue_sync', 'rescue_sync_last_runtime', [
+            'type' => 'string',
+            'default' => '',
+        ] );
+
+        register_setting( 'rescue_sync', 'rescue_sync_last_memory', [
+            'type' => 'string',
+            'default' => '',
+        ] );
+
         register_setting( 'rescue_sync', 'rescue_sync_species_filter', [
             'type'              => 'string',
             'sanitize_callback' => 'sanitize_text_field',

--- a/rescuegroups-sync/src/Sync/Runner.php
+++ b/rescuegroups-sync/src/Sync/Runner.php
@@ -60,6 +60,7 @@ class Runner {
      * Run the sync process.
      */
     public function run() : void {
+        $start_time = microtime( true );
         $params = [];
         $species_filter = Options::get( 'species_filter', '' );
         $status_filter  = Options::get( 'status_filter', '' );
@@ -69,6 +70,9 @@ class Runner {
         if ( $status_filter ) {
             $params['status'] = $status_filter;
         }
+
+        $store_raw     = (bool) Options::get( 'store_raw', false );
+        $raw_retention = absint( Options::get( 'raw_retention', 30 ) );
 
         $results = $this->client->fetchAll( $params );
 
@@ -138,7 +142,16 @@ class Runner {
             $post_id = wp_insert_post( $post_args );
             if ( ! is_wp_error( $post_id ) ) {
                 update_post_meta( $post_id, 'rescuegroups_id', $animal_id );
-                update_post_meta( $post_id, 'rescuegroups_raw', wp_json_encode( $animal ) );
+                if ( $store_raw ) {
+                    $trimmed = [
+                        'id'         => $animal_id,
+                        'attributes' => $animal['attributes'] ?? [],
+                    ];
+                    if ( isset( $animal['relationships'] ) ) {
+                        $trimmed['relationships'] = $animal['relationships'];
+                    }
+                    update_post_meta( $post_id, 'rescuegroups_raw', wp_json_encode( $trimmed ) );
+                }
                 update_post_meta( $post_id, self::META_SPECIES, sanitize_text_field( $species ) );
                 update_post_meta( $post_id, self::META_BREED, sanitize_text_field( $breed ) );
                 update_post_meta( $post_id, self::META_AGE, sanitize_text_field( $age ) );
@@ -160,5 +173,38 @@ class Runner {
         update_option( 'rescue_sync_manifest', $manifest );
         update_option( 'rescue_sync_last_sync', current_time( 'timestamp' ) );
         update_option( 'rescue_sync_last_status', 'success' );
+
+        if ( $raw_retention > 0 ) {
+            $this->pruneRawMeta( $raw_retention );
+        }
+
+        $runtime = sprintf( '%.2f s', microtime( true ) - $start_time );
+        $memory  = size_format( memory_get_peak_usage(), 2 );
+        update_option( 'rescue_sync_last_runtime', $runtime );
+        update_option( 'rescue_sync_last_memory', $memory );
+    }
+
+    /**
+     * Delete raw meta older than the given number of days.
+     *
+     * @param int $days Retention period.
+     */
+    private function pruneRawMeta( int $days ) : void {
+        $query = new \WP_Query([
+            'post_type'      => 'adoptable_pet',
+            'posts_per_page' => -1,
+            'fields'         => 'ids',
+            'meta_key'       => 'rescuegroups_raw',
+            'date_query'     => [
+                [
+                    'column' => 'post_modified_gmt',
+                    'before' => gmdate( 'Y-m-d', time() - $days * DAY_IN_SECONDS ),
+                ],
+            ],
+        ]);
+
+        foreach ( $query->posts as $post_id ) {
+            delete_post_meta( $post_id, 'rescuegroups_raw' );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- trim optional stored API data and add retention pruning
- profile runtime and memory usage of sync
- expose new options on the settings page
- document new features

## Testing
- `find rescuegroups-sync -name '*.php' -print0 | xargs -0 -n1 php -l` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b53eb3aa0832697db02ab935f3637