### PR TITLE
Update manifest key and merge API includes

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -25,9 +25,9 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
 3. Enter your API key and save.  
 4. Choose how often to sync and/or click **Run Sync Now** for a manual sync.  
 5. Set **Fetch Limit** (how many animals to pull per run; default `100`).  
-6. Optionally specify **Species** and **Status** filters to limit which pets are synced.  
-7. Use **Reset Manifest** to clear the stored ID list and re-sync everything.  
-8. Customize your **Archive Slug** (default `adopt`) and **Default Query Options** (number of pets, featured-only, etc.).  
+6. Optionally specify **Species** and **Status** filters to limit which pets are synced.
+7. Use **Reset Manifest** to clear the stored manifest and re-sync everything.
+8. Customize your **Archive Slug** (default `adopt`) and **Default Query Options** (number of pets, featured-only, etc.).
 9. Use the widgets/shortcodes to display pets:  
    - Flag posts **Featured** or **Hidden** in the post editor  
    - Widgets can show featured-first or featured-only  

--- a/rescuegroups-sync/src/API/Client.php
+++ b/rescuegroups-sync/src/API/Client.php
@@ -60,8 +60,8 @@ class Client {
      * @return array Combined response data.
      */
     public function fetchAll( array $params = [] ) : array {
-        $page     = 1;
-        $all      = [ 'data' => [] ];
+        $page = 1;
+        $all  = [ 'data' => [], 'included' => [] ];
 
         do {
             $results = $this->fetchPage( $page, $params );
@@ -69,6 +69,17 @@ class Client {
                 $all['data'] = array_merge( $all['data'], $results['data'] );
             } else {
                 break;
+            }
+
+            if ( isset( $results['included'] ) && is_array( $results['included'] ) ) {
+                foreach ( $results['included'] as $type => $items ) {
+                    if ( ! isset( $all['included'][ $type ] ) ) {
+                        $all['included'][ $type ] = [];
+                    }
+                    if ( is_array( $items ) ) {
+                        $all['included'][ $type ] = array_replace( $all['included'][ $type ], $items );
+                    }
+                }
             }
             $page++;
         } while ( ! empty( $results['data'] ) );

--- a/rescuegroups-sync/src/Admin/ActionHandlers.php
+++ b/rescuegroups-sync/src/Admin/ActionHandlers.php
@@ -37,7 +37,7 @@ class ActionHandlers {
             wp_die( __( 'Unauthorized', 'rescuegroups-sync' ) );
         }
         check_admin_referer( 'rescue_sync_reset_manifest' );
-        delete_option( 'rescue_sync_manifest_ids' );
+        delete_option( 'rescue_sync_manifest' );
         delete_option( 'rescue_sync_manifest_timestamp' );
         wp_redirect( wp_get_referer() );
         exit;

--- a/rescuegroups-sync/src/Admin/SettingsRegistrar.php
+++ b/rescuegroups-sync/src/Admin/SettingsRegistrar.php
@@ -59,10 +59,9 @@ class SettingsRegistrar {
             'default'           => '',
         ] );
 
-        register_setting( 'rescue_sync', 'rescue_sync_manifest_ids', [
-            'type'              => 'array',
-            'sanitize_callback' => 'wp_parse_id_list',
-            'default'           => [],
+        register_setting( 'rescue_sync', 'rescue_sync_manifest', [
+            'type'    => 'array',
+            'default' => [],
         ] );
 
         register_setting( 'rescue_sync', 'rescue_sync_manifest_timestamp', [


### PR DESCRIPTION
## Summary
- change option key to `rescue_sync_manifest`
- clear manifest during reset
- combine `included` info across API pages
- document reset manifest usage

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b53e35bb88326ba9409b0716c3be4