### PR TITLE
Initialize npm and add build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ wp-config.php
 # Note: If you wish to whitelist themes,
 # uncomment the next line
 #/wp-content/themes
+# Node modules
+node_modules/
+package-lock.json

--- a/rescuegroups-sync/package.json
+++ b/rescuegroups-sync/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "rescuegroups-sync",
+  "version": "1.0.0",
+  "description": "This plugin synchronizes adoptable pets from the RescueGroups.org API and registers a custom post type for displaying them.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "wp-scripts build",
+    "start": "wp-scripts start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@wordpress/scripts": "^30.18.0"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize npm project for the plugin
- add `@wordpress/scripts` dev dependency
- configure build and start scripts
- ignore node artifacts

## Testing
- `npm install @wordpress/scripts --save-dev` *(outputs omitted)*

------
https://chatgpt.com/codex/tasks/task_e_684b59c26fc883269952b50f7f14b63a