### PR TITLE
Handle API errors

### DIFF
--- a/rescuegroups-sync/README.md
+++ b/rescuegroups-sync/README.md
@@ -34,7 +34,7 @@ This plugin synchronizes adoptable pets from the RescueGroups.org API and regist
    - Widgets can show featured-first or featured-only
    - The `[adoptable_pets]` shortcode supports `species`, `breed`, `orderby`, and `order` parameters
 
-The settings page also displays the runtime and peak memory usage from the last sync to help diagnose performance issues.
+The settings page also displays the runtime and peak memory usage from the last sync to help diagnose performance issues. Any errors returned from the API will be shown next to the last sync time so you can spot connection issues.
 
 The archive slug controls the URL of the adoptable pets archive page (default `adopt`).
 Default query options set how many pets display and whether only featured pets are shown when no parameters are provided.

--- a/rescuegroups-sync/src/API/Client.php
+++ b/rescuegroups-sync/src/API/Client.php
@@ -46,6 +46,13 @@ class Client {
         $response = wp_remote_get( $url, [ 'headers' => [ 'x-api-key' => $this->apiKey ] ] );
 
         if ( is_wp_error( $response ) ) {
+            update_option( 'rescue_sync_last_status', 'Error: ' . $response->get_error_message() );
+            return [];
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        if ( 200 !== $code ) {
+            update_option( 'rescue_sync_last_status', 'HTTP Error ' . $code );
             return [];
         }
 

--- a/rescuegroups-sync/src/Sync/Runner.php
+++ b/rescuegroups-sync/src/Sync/Runner.php
@@ -88,7 +88,10 @@ class Runner {
 
         if ( empty( $results['data'] ) || ! is_array( $results['data'] ) ) {
             update_option( 'rescue_sync_last_sync', current_time( 'timestamp' ) );
-            update_option( 'rescue_sync_last_status', 'no_data' );
+            $status = Options::get( 'last_status', '' );
+            if ( 0 !== strpos( $status, 'HTTP Error' ) && 0 !== strpos( $status, 'Error:' ) ) {
+                update_option( 'rescue_sync_last_status', 'no_data' );
+            }
             return;
         }
 


### PR DESCRIPTION
## Summary
- show RescueGroups API errors on the settings page
- keep last_status when an API request fails

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b5b38ba90832687c8eb319d17a371