### PR TITLE
Use wp_date for last sync

### DIFF
--- a/rescuegroups-sync/src/Admin/SettingsPage.php
+++ b/rescuegroups-sync/src/Admin/SettingsPage.php
@@ -161,7 +161,7 @@ class SettingsPage {
                         <td>
                             <?php
                             if ( $last_sync ) {
-                                echo esc_html( date( 'Y-m-d H:i:s', intval( $last_sync ) ) );
+                                echo esc_html( wp_date( 'Y-m-d H:i:s', intval( $last_sync ) ) );
                             } else {
                                 esc_html_e( 'Never', 'rescuegroups-sync' );
                             }


### PR DESCRIPTION
## Summary
- use `wp_date` instead of `date` for displaying the last sync timestamp

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b5b44cbe08326a3526e8ebe0c9268