### PR TITLE
Flush rewrite on archive slug change

### DIFF
--- a/rescuegroups-sync/src/CPT/Register.php
+++ b/rescuegroups-sync/src/CPT/Register.php
@@ -7,6 +7,21 @@ use RescueSync\Utils\Options;
  * Register custom post type and related taxonomies/meta.
  */
 class Register {
+    /**
+     * Flush rewrite rules when the archive slug changes.
+     *
+     * @param string $old_value Previous option value.
+     * @param string $value     New option value.
+     */
+    public static function flushRewrite( $old_value, $value ) : void {
+        if ( ! is_admin() ) {
+            return;
+        }
+
+        if ( $old_value !== $value ) {
+            flush_rewrite_rules();
+        }
+    }
     /** Register hooks. */
     public function register() : void {
         add_action( 'init', [ $this, 'registerCPT' ] );

--- a/rescuegroups-sync/src/Plugin.php
+++ b/rescuegroups-sync/src/Plugin.php
@@ -22,6 +22,7 @@ class Plugin {
         $runner  = new Runner( $client );
 
         add_action( 'update_option_rescue_sync_frequency', [ Runner::class, 'updateSchedule' ], 10, 2 );
+        add_action( 'update_option_rescue_sync_archive_slug', [ CPTRegister::class, 'flushRewrite' ], 10, 2 );
 
         $settingsRegistrar = new SettingsRegistrar();
         ( new CPTRegister() )->register();


### PR DESCRIPTION
## Summary
- hook archive slug option update to flush rewrite rules
- implement `flushRewrite()` in `CPT\Register`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b5b48c0048326abfe20949385b7f9