### PR TITLE
Fix settings error display

### DIFF
--- a/rescuegroups-sync/src/Admin/SettingsPage.php
+++ b/rescuegroups-sync/src/Admin/SettingsPage.php
@@ -51,6 +51,7 @@ class SettingsPage {
         ?>
         <div class="wrap">
             <h1><?php echo esc_html__( 'Rescue Sync Settings', 'rescuegroups-sync' ); ?></h1>
+            <?php settings_errors(); ?>
             <form method="post" action="options.php">
                 <?php
                 settings_fields( 'rescue_sync' );

--- a/rescuegroups-sync/src/Plugin.php
+++ b/rescuegroups-sync/src/Plugin.php
@@ -25,10 +25,12 @@ class Plugin {
         add_action( 'update_option_rescue_sync_archive_slug', [ CPTRegister::class, 'flushRewrite' ], 10, 2 );
 
         $settingsRegistrar = new SettingsRegistrar();
+        $settingsPage      = new SettingsPage( $settingsRegistrar );
+
         ( new CPTRegister() )->register();
         ( new MetaBoxRegistrar() )->register();
-        $settingsRegistrar->register();
-        ( new SettingsPage( $settingsRegistrar ) )->register();
+        $settingsPage->registerSettings();
+        $settingsPage->register();
         ( new ActionHandlers( $runner ) )->register();
         ( new WidgetRegistrar() )->register();
         ( new ShortcodeHandlers() )->register();


### PR DESCRIPTION
## Summary
- show `settings_errors()` on the settings page
- hook settings registration into `admin_init`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b5ea9eda48326bbeadfb331bfe9fb