### PR TITLE
Display notices after sync actions

### DIFF
--- a/rescuegroups-sync/src/Admin/ActionHandlers.php
+++ b/rescuegroups-sync/src/Admin/ActionHandlers.php
@@ -27,6 +27,13 @@ class ActionHandlers {
         }
         check_admin_referer( 'rescue_sync_manual' );
         $this->runner->run();
+        add_settings_error(
+            'rescue_sync_messages',
+            'manual_sync_success',
+            __( 'Sync completed successfully.', 'rescuegroups-sync' ),
+            'updated'
+        );
+        set_transient( 'settings_errors', get_settings_errors(), 30 );
         wp_redirect( wp_get_referer() );
         exit;
     }
@@ -39,6 +46,13 @@ class ActionHandlers {
         check_admin_referer( 'rescue_sync_reset_manifest' );
         delete_option( 'rescue_sync_manifest' );
         delete_option( 'rescue_sync_manifest_timestamp' );
+        add_settings_error(
+            'rescue_sync_messages',
+            'manifest_reset_success',
+            __( 'Sync manifest reset.', 'rescuegroups-sync' ),
+            'updated'
+        );
+        set_transient( 'settings_errors', get_settings_errors(), 30 );
         wp_redirect( wp_get_referer() );
         exit;
     }

--- a/rescuegroups-sync/src/Admin/SettingsPage.php
+++ b/rescuegroups-sync/src/Admin/SettingsPage.php
@@ -51,6 +51,7 @@ class SettingsPage {
         ?>
         <div class="wrap">
             <h1><?php echo esc_html__( 'Rescue Sync Settings', 'rescuegroups-sync' ); ?></h1>
+            <?php settings_errors( 'rescue_sync_messages' ); ?>
             <form method="post" action="options.php">
                 <?php
                 settings_fields( 'rescue_sync' );


### PR DESCRIPTION
## Summary
- inform admins when manual sync finishes or manifest resets
- show admin notices on settings page

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b5eb347988326afa0691fa2ffa331