### PR TITLE
Register settings via SettingsPage

### DIFF
--- a/rescuegroups-sync/src/Plugin.php
+++ b/rescuegroups-sync/src/Plugin.php
@@ -25,10 +25,12 @@ class Plugin {
         add_action( 'update_option_rescue_sync_archive_slug', [ CPTRegister::class, 'flushRewrite' ], 10, 2 );
 
         $settingsRegistrar = new SettingsRegistrar();
+        $settingsPage      = new SettingsPage( $settingsRegistrar );
+
         ( new CPTRegister() )->register();
         ( new MetaBoxRegistrar() )->register();
-        $settingsRegistrar->register();
-        ( new SettingsPage( $settingsRegistrar ) )->register();
+        $settingsPage->registerSettings();
+        $settingsPage->register();
         ( new ActionHandlers( $runner ) )->register();
         ( new WidgetRegistrar() )->register();
         ( new ShortcodeHandlers() )->register();


### PR DESCRIPTION
## Summary
- register options through `SettingsPage::registerSettings` so they hook into `admin_init`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b5eb6e66483268400505a581f643e