### PR TITLE
Remove leftover TODO in uninstall script

### DIFF
--- a/rescuegroups-sync/uninstall.php
+++ b/rescuegroups-sync/uninstall.php
@@ -66,4 +66,3 @@ foreach ( $options as $option ) {
     delete_option( $option );
 }
 
-// TODO: If any other cleanup is required (custom tables, transients, etc.), add it here.


### PR DESCRIPTION
## Summary
- clean up uninstall script by removing outdated TODO comment

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b73b0c6fc832692ea79d5df7a57fb